### PR TITLE
fix: explicitely set SonarQubeTestProject

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/Testably.Abstractions.FluentAssertions.csproj
+++ b/Source/Testably.Abstractions.FluentAssertions/Testably.Abstractions.FluentAssertions.csproj
@@ -5,6 +5,7 @@
 		<Description>FluentAssertions extension methods for `Testably.Abstractions`.</Description>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>
 		<IsTestProject>false</IsTestProject>
+		<SonarQubeTestProject>false</SonarQubeTestProject>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Set `SonarQubeTestProject` to `false` as specified [here](https://github.com/SonarSource/sonar-scanner-msbuild/wiki/Analysis-of-product-projects-vs.-test-projects#explicit-setting-the-project-type).