### PR TITLE
fix: links to project on nuget.org

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -5,12 +5,12 @@
 	
 	<PropertyGroup>
 		<Authors>Testably</Authors>
-		<Copyright>Copyright (c) 2022 Testably</Copyright>
-		<PackageTags>abstractions testing</PackageTags>
-		<PackageProjectUrl>https://github.com/Testably/Testably.Abstractions</PackageProjectUrl>
+		<Copyright>Copyright (c) 2023 Testably</Copyright>
+		<PackageTags>abstractions testing fluent-assertions</PackageTags>
+		<PackageProjectUrl>https://github.com/Testably/Testably.Abstractions.FluentAssertions</PackageProjectUrl>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>
-		<RepositoryUrl>https://github.com/Testably/Testably.Abstractions.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Testably/Testably.Abstractions.FluentAssertions.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<MinVerTagPrefix>v</MinVerTagPrefix>
 	</PropertyGroup>


### PR DESCRIPTION
The links to the project on Nuget.org are incorrect.