### PR TITLE
refactor: remove retry-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,10 +77,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build --collect:"XPlat Code Coverage"
-          attempt_limit: 2
+        run: dotnet test --no-build --collect:"XPlat Code Coverage"
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:
@@ -104,10 +101,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build --collect:"XPlat Code Coverage"
-          attempt_limit: 2
+        run: dotnet test --no-build --collect:"XPlat Code Coverage"
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:
@@ -131,10 +125,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build --collect:"XPlat Code Coverage"
-          attempt_limit: 2
+        run: dotnet test --no-build --collect:"XPlat Code Coverage"
       - name: Upload coverage
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
-          attempt_limit: 2
+        run: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
       - name: Upload test results (MacOS)
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
@@ -56,10 +53,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
-          attempt_limit: 2
+        run: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
       - name: Upload test results (Ubuntu)
         if: ${{ always() }}
         uses: actions/upload-artifact@v3
@@ -89,10 +83,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
-          attempt_limit: 2
+        run: dotnet test --no-build --collect:"XPlat Code Coverage" --logger trx --results-directory "TestResults"
       - name: Upload test results (Windows)
         if: ${{ always() }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,10 +88,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build
-          attempt_limit: 2
+        run: dotnet test --no-build
 
   test-ubuntu:
     name: Test (Ubuntu)
@@ -115,10 +112,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build
-          attempt_limit: 2
+        run: dotnet test --no-build
 
   test-windows:
     name: Test (Windows)
@@ -142,10 +136,7 @@ jobs:
       - name: Build solution
         run: dotnet build /p:NetCoreOnly=True --configuration "Release"
       - name: Run tests
-        uses: Wandalen/wretry.action@v1.3.0
-        with:
-          command: dotnet test --no-build
-          attempt_limit: 2
+        run: dotnet test --no-build
 
   test-net-framework:
     name: Test (.NET Framework)


### PR DESCRIPTION
Remove the [retry action](https://github.com/marketplace/actions/retry-action) from the build pipelines as it is sometimes the reason for build errors.