### PR TITLE
fix: add missing default identifiers

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
@@ -21,6 +21,7 @@ public class FileInfoAssertions :
 		string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
 			.Given(() => Subject)
 			.ForCondition(fileInfo => !fileInfo.IsReadOnly)

--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemAssertions.cs
@@ -43,6 +43,7 @@ public class FileSystemAssertions :
 		string path, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
 			.ForCondition(!string.IsNullOrEmpty(path))
 			.FailWith("You can't assert that a file exists if you don't pass a proper name.")
@@ -87,6 +88,7 @@ public class FileSystemAssertions :
 		string path, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
 			.ForCondition(!string.IsNullOrEmpty(path))
 			.FailWith(

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
@@ -62,7 +62,8 @@ public class DirectoryInfoAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(fileName);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be(
+				$"Expected directory \"{directoryName}\" to contain at least one file matching \"{fileName}\" {because}, but none was found.");
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
@@ -27,8 +27,9 @@ public class FileInfoAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(fileDescription.Name);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be(
+				$"Expected file \"{fileDescription.Name}\" not to be read-only {because}, but it was.");
 	}
 
 	[Theory]
@@ -75,7 +76,8 @@ public class FileInfoAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(fileDescription.Name);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be(
+				$"Expected file \"{fileDescription.Name}\" to be read-only {because}, but it was not.");
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemAssertionsTests.cs
@@ -81,8 +81,9 @@ public class FileSystemAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(path);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be(
+				$"Expected filesystem to contain directory \"{path}\" {because}, but it did not exist.");
 	}
 
 	[Theory]
@@ -156,8 +157,8 @@ public class FileSystemAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(path);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be($"Expected filesystem to contain file \"{path}\" {because}, but it did not exist.");
 	}
 
 	[Theory]
@@ -223,8 +224,9 @@ public class FileSystemAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(path);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be(
+				$"Expected filesystem to not contain directory \"{path}\" {because}, but it did exist.");
 	}
 
 	[Theory]
@@ -296,8 +298,8 @@ public class FileSystemAssertionsTests
 		});
 
 		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain(path);
-		exception.Message.Should().Contain(because);
+		exception!.Message.Should()
+			.Be($"Expected filesystem to not contain file \"{path}\" {because}, but it did exist.");
 	}
 
 	[Theory]


### PR DESCRIPTION
Add missing default identifiers to the AssertionScope