### PR TITLE
refactor: split assertions in separate classes to use correct grammar

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -2,7 +2,7 @@
 
 	<Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props"
 	        Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')" />
-	
+
 	<PropertyGroup>
 		<Authors>Testably</Authors>
 		<Copyright>Copyright (c) 2023 Testably</Copyright>

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -1,0 +1,26 @@
+﻿namespace Testably.Abstractions.FluentAssertions;
+
+/// <summary>
+///     Assertions on <see cref="IDirectoryInfo" />.
+/// </summary>
+public class DirectoryAssertions :
+	ReferenceTypeAssertions<IDirectoryInfo, DirectoryAssertions>
+{
+	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
+	protected override string Identifier => "directory";
+
+	internal DirectoryAssertions(IDirectoryInfo instance)
+		: base(instance)
+	{
+	}
+
+	/// <summary>
+	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
+	/// </summary>
+	public AndConstraint<DirectoryAssertions> HasFileMatching(
+		string searchPattern = "*", string because = "", params object[] becauseArgs)
+	{
+		Subject.Should().HaveFileMatching(searchPattern, because, becauseArgs);
+		return new AndConstraint<DirectoryAssertions>(this);
+	}
+}

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -17,7 +17,7 @@ public class DirectoryInfoAssertions :
 	/// <summary>
 	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryInfoAssertions> HasFileMatching(
+	public AndConstraint<DirectoryInfoAssertions> HaveFileMatching(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion

--- a/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
@@ -1,0 +1,59 @@
+﻿using System.Text;
+
+namespace Testably.Abstractions.FluentAssertions;
+
+/// <summary>
+///     Assertions on <see cref="IFileInfo" />.
+/// </summary>
+public class FileAssertions :
+	ReferenceTypeAssertions<IFileInfo, FileAssertions>
+{
+	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
+	protected override string Identifier => "file";
+
+	internal FileAssertions(IFileInfo instance)
+		: base(instance)
+	{
+	}
+
+	/// <summary>
+	///     Asserts that the current file is not read-only.
+	/// </summary>
+	public AndConstraint<FileAssertions> IsNotReadOnly(
+		string because = "", params object[] becauseArgs)
+	{
+		Subject.Should().NotBeReadOnly(because, becauseArgs);
+		return new AndConstraint<FileAssertions>(this);
+	}
+
+	/// <summary>
+	///     Asserts that the current file is read-only.
+	/// </summary>
+	public AndConstraint<FileAssertions> IsReadOnly(
+		string because = "", params object[] becauseArgs)
+	{
+		Subject.Should().BeReadOnly(because, becauseArgs);
+		return new AndConstraint<FileAssertions>(this);
+	}
+
+	/// <summary>
+	///     Asserts that the string content of the current file matches the <paramref name="pattern" />.
+	/// </summary>
+	public AndConstraint<FileAssertions> HasContentMatching(
+		Match pattern, string because = "", params object[] becauseArgs)
+	{
+		Subject.Should().HaveContentMatching(pattern, because, becauseArgs);
+		return new AndConstraint<FileAssertions>(this);
+	}
+
+	/// <summary>
+	///     Asserts that the string content of the current file using the given <paramref name="encoding" />
+	///     matches the <paramref name="pattern" />.
+	/// </summary>
+	public AndConstraint<FileAssertions> HasContentMatching(
+		Match pattern, Encoding encoding, string because = "", params object[] becauseArgs)
+	{
+		Subject.Should().HaveContentMatching(pattern, encoding, because, becauseArgs);
+		return new AndConstraint<FileAssertions>(this);
+	}
+}

--- a/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 
 namespace Testably.Abstractions.FluentAssertions;
 
@@ -19,7 +19,7 @@ public class FileInfoAssertions :
 	/// <summary>
 	///     Asserts that the current file is not read-only.
 	/// </summary>
-	public AndConstraint<FileInfoAssertions> IsNotReadOnly(
+	public AndConstraint<FileInfoAssertions> NotBeReadOnly(
 		string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -37,7 +37,7 @@ public class FileInfoAssertions :
 	/// <summary>
 	///     Asserts that the current file is read-only.
 	/// </summary>
-	public AndConstraint<FileInfoAssertions> IsReadOnly(
+	public AndConstraint<FileInfoAssertions> BeReadOnly(
 		string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -55,7 +55,7 @@ public class FileInfoAssertions :
 	/// <summary>
 	///     Asserts that the string content of the current file matches the <paramref name="pattern" />.
 	/// </summary>
-	public AndConstraint<FileInfoAssertions> HasContentMatching(
+	public AndConstraint<FileInfoAssertions> HaveContentMatching(
 		Match pattern, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -75,7 +75,7 @@ public class FileInfoAssertions :
 	///     Asserts that the string content of the current file using the given <paramref name="encoding" />
 	///     matches the <paramref name="pattern" />.
 	/// </summary>
-	public AndConstraint<FileInfoAssertions> HasContentMatching(
+	public AndConstraint<FileInfoAssertions> HaveContentMatching(
 		Match pattern, Encoding encoding, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion

--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemAssertions.cs
@@ -17,7 +17,7 @@ public class FileSystemAssertions :
 	/// <summary>
 	///     Asserts that a directory at <paramref name="path" /> exists in the file system.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, DirectoryInfoAssertions> HaveDirectory(
+	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HaveDirectory(
 		string path, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -32,14 +32,14 @@ public class FileSystemAssertions :
 				"Expected {context} to contain directory {0}{reason}, but it did not exist.",
 				_ => path, directoryInfo => directoryInfo.Name);
 
-		return new AndWhichConstraint<FileSystemAssertions, DirectoryInfoAssertions>(this,
-			new DirectoryInfoAssertions(Subject.DirectoryInfo.New(path)));
+		return new AndWhichConstraint<FileSystemAssertions, DirectoryAssertions>(this,
+			new DirectoryAssertions(Subject.DirectoryInfo.New(path)));
 	}
 
 	/// <summary>
 	///     Asserts that a file at <paramref name="path" /> exists in the file system.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, FileInfoAssertions> HaveFile(
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HaveFile(
 		string path, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -54,14 +54,14 @@ public class FileSystemAssertions :
 				"Expected {context} to contain file {0}{reason}, but it did not exist.",
 				_ => path, fileInfo => fileInfo.Name);
 
-		return new AndWhichConstraint<FileSystemAssertions, FileInfoAssertions>(this,
-			new FileInfoAssertions(Subject.FileInfo.New(path)));
+		return new AndWhichConstraint<FileSystemAssertions, FileAssertions>(this,
+			new FileAssertions(Subject.FileInfo.New(path)));
 	}
 
 	/// <summary>
 	///     Asserts that no directory at <paramref name="path" /> exists in the file system.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, DirectoryInfoAssertions> NotHaveDirectory(
+	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> NotHaveDirectory(
 		string path, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -77,14 +77,14 @@ public class FileSystemAssertions :
 				"Expected {context} to not contain directory {0}{reason}, but it did exist.",
 				_ => path, directoryInfo => directoryInfo.Name);
 
-		return new AndWhichConstraint<FileSystemAssertions, DirectoryInfoAssertions>(this,
-			new DirectoryInfoAssertions(Subject.DirectoryInfo.New(path)));
+		return new AndWhichConstraint<FileSystemAssertions, DirectoryAssertions>(this,
+			new DirectoryAssertions(Subject.DirectoryInfo.New(path)));
 	}
 
 	/// <summary>
 	///     Asserts that no file at <paramref name="path" /> exists in the file system.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, FileInfoAssertions> NotHaveFile(
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> NotHaveFile(
 		string path, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -100,7 +100,7 @@ public class FileSystemAssertions :
 				"Expected {context} to not contain file {0}{reason}, but it did exist.",
 				_ => path, fileInfo => fileInfo.Name);
 
-		return new AndWhichConstraint<FileSystemAssertions, FileInfoAssertions>(this,
-			new FileInfoAssertions(Subject.FileInfo.New(path)));
+		return new AndWhichConstraint<FileSystemAssertions, FileAssertions>(this,
+			new FileAssertions(Subject.FileInfo.New(path)));
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemExtensions.cs
@@ -6,6 +6,20 @@
 public static class FileSystemExtensions
 {
 	/// <summary>
+	///     Returns a <see cref="DirectoryAssertions" /> object that can be used to
+	///     assert the current <see cref="IDirectoryInfo" />.
+	/// </summary>
+	public static DirectoryInfoAssertions Should(this IDirectoryInfo instance)
+		=> new(instance);
+
+	/// <summary>
+	///     Returns a <see cref="FileAssertions" /> object that can be used to
+	///     assert the current <see cref="IFileInfo" />.
+	/// </summary>
+	public static FileInfoAssertions Should(this IFileInfo instance)
+		=> new(instance);
+
+	/// <summary>
 	///     Returns a <see cref="FileSystemAssertions" /> object that can be used to
 	///     assert the current <see cref="IFileSystem" />.
 	/// </summary>

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryAssertionsTests.cs
@@ -1,28 +1,26 @@
 ﻿using AutoFixture.Xunit2;
 using FluentAssertions;
 using System;
-using System.IO.Abstractions;
 using Testably.Abstractions.Testing;
 using Xunit;
 
 namespace Testably.Abstractions.FluentAssertions.Tests;
 
-public class DirectoryInfoAssertionsTests
+public class DirectoryAssertionsTests
 {
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HaveFileMatching_InvalidFileName_ShouldThrow(string? invalidFileName,
-		string because)
+	public void HasFileMatching_InvalidFileName_ShouldThrow(string? invalidFileName, string because)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
 			.WithSubdirectory("foo");
-		IDirectoryInfo sut = fileSystem.DirectoryInfo.New("foo");
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory("foo").Which;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveFileMatching(invalidFileName!, because);
+			sut.HasFileMatching(invalidFileName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -32,7 +30,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveFileMatching_WithMatchingFile_ShouldNotThrow(
+	public void HasFileMatching_WithMatchingFile_ShouldNotThrow(
 		string directoryName,
 		string fileName)
 	{
@@ -40,14 +38,14 @@ public class DirectoryInfoAssertionsTests
 		fileSystem.Initialize()
 			.WithSubdirectory(directoryName).Initialized(d => d
 				.WithFile(fileName));
-		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
-		sut.Should().HaveFileMatching(fileName);
+		sut.HasFileMatching(fileName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveFileMatching_WithoutMatchingFile_ShouldThrow(
+	public void HasFileMatching_WithoutMatchingFile_ShouldThrow(
 		string directoryName,
 		string fileName,
 		string because)
@@ -56,11 +54,11 @@ public class DirectoryInfoAssertionsTests
 		fileSystem.Initialize()
 			.WithSubdirectory(directoryName).Initialized(d => d
 				.WithFile("not-matching-file"));
-		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveFileMatching(fileName, because);
+			sut.HasFileMatching(fileName, because);
 		});
 
 		exception.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileAssertionsTests.cs
@@ -1,7 +1,6 @@
 ﻿using AutoFixture.Xunit2;
 using FluentAssertions;
 using System;
-using System.IO.Abstractions;
 using System.Text;
 using Testably.Abstractions.Testing;
 using Testably.Abstractions.Testing.FileSystemInitializer;
@@ -9,48 +8,48 @@ using Xunit;
 
 namespace Testably.Abstractions.FluentAssertions.Tests;
 
-public class FileInfoAssertionsTests
+public class FileAssertionsTests
 {
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_FullContent_ShouldNotThrow(
+	public void HasContentMatching_FullContent_ShouldNotThrow(
 		string content, string fileName)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
 			.WithFile(fileName).Which(f => f.HasStringContent(content));
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 
-		sut.Should().HaveContentMatching(content);
+		sut.HasContentMatching(content);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_FullContent_WithEncoding_ShouldNotThrow(
+	public void HasContentMatching_FullContent_WithEncoding_ShouldNotThrow(
 		Encoding encoding, string content, string fileName)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize();
 		fileSystem.File.WriteAllText(fileName, content, encoding);
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 
-		sut.Should().HaveContentMatching(content, encoding);
+		sut.HasContentMatching(content, encoding);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_OnlyPartOfContentWithoutWildcards_ShouldThrow(
+	public void HasContentMatching_OnlyPartOfContentWithoutWildcards_ShouldThrow(
 		string content, string fileName, string because)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
 			.WithFile(fileName).Which(f => f.HasStringContent(content));
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 		string pattern = content.Substring(1);
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveContentMatching(pattern, because);
+			sut.HasContentMatching(pattern, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -61,18 +60,18 @@ public class FileInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_OnlyPartOfContentWithoutWildcards_WithEncoding_ShouldThrow(
+	public void HasContentMatching_OnlyPartOfContentWithoutWildcards_WithEncoding_ShouldThrow(
 		Encoding encoding, string content, string fileName, string because)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize();
 		fileSystem.File.WriteAllText(fileName, content, encoding);
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 		string pattern = content.Substring(1);
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveContentMatching(pattern, encoding, because);
+			sut.HasContentMatching(pattern, encoding, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -83,47 +82,47 @@ public class FileInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_OnlyPartOfContentWithWildcard_ShouldNotThrow(
+	public void HasContentMatching_OnlyPartOfContentWithWildcard_ShouldNotThrow(
 		string content, string fileName)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
 			.WithFile(fileName).Which(f => f.HasStringContent(content));
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 		string pattern = "*" + content.Substring(1);
 
-		sut.Should().HaveContentMatching(pattern);
+		sut.HasContentMatching(pattern);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_OnlyPartOfContentWithWildcard_WithEncoding_ShouldNotThrow(
+	public void HasContentMatching_OnlyPartOfContentWithWildcard_WithEncoding_ShouldNotThrow(
 		Encoding encoding, string content, string fileName)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize();
 		fileSystem.File.WriteAllText(fileName, content, encoding);
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 		string pattern = "*" + content.Substring(1);
 
-		sut.Should().HaveContentMatching(pattern);
+		sut.HasContentMatching(pattern);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveContentMatching_WithEncodingMismatch_ShouldThrow(
+	public void HasContentMatching_WithEncodingMismatch_ShouldThrow(
 		string fileName, string because)
 	{
 		string content = "Dans mes rêves";
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize();
 		fileSystem.File.WriteAllText(fileName, content, Encoding.ASCII);
-		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 		string pattern = content;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveContentMatching(pattern, Encoding.Default, because);
+			sut.HasContentMatching(pattern, Encoding.Default, because);
 		});
 
 		exception.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
@@ -13,6 +13,42 @@ public class FileInfoAssertionsTests
 {
 	[Theory]
 	[AutoData]
+	public void BeReadOnly_WithReadOnlyFile_ShouldNotThrow(FileDescription fileDescription)
+	{
+		fileDescription.IsReadOnly = true;
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.With(fileDescription);
+		IFileInfo sut = fileSystem.FileInfo.New(fileDescription.Name);
+
+		sut.Should().BeReadOnly();
+	}
+
+	[Theory]
+	[AutoData]
+	public void BeReadOnly_WithWritableFile_ShouldThrow(
+		FileDescription fileDescription,
+		string because)
+	{
+		fileDescription.IsReadOnly = false;
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.With(fileDescription);
+		IFileInfo sut = fileSystem.FileInfo.New(fileDescription.Name);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().BeReadOnly(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected file \"{fileDescription.Name}\" to be read-only {because}, but it was not.");
+	}
+
+	[Theory]
+	[AutoData]
 	public void HaveContentMatching_FullContent_ShouldNotThrow(
 		string content, string fileName)
 	{
@@ -134,7 +170,7 @@ public class FileInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void IsNotReadOnly_WithReadOnlyFile_ShouldThrow(
+	public void NotBeReadOnly_WithReadOnlyFile_ShouldThrow(
 		FileDescription fileDescription,
 		string because)
 	{
@@ -142,11 +178,11 @@ public class FileInfoAssertionsTests
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
 			.With(fileDescription);
-		FileAssertions? sut = fileSystem.Should().HaveFile(fileDescription.Name).Which;
+		IFileInfo sut = fileSystem.FileInfo.New(fileDescription.Name);
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.IsNotReadOnly(because);
+			sut.Should().NotBeReadOnly(because);
 		});
 
 		exception.Should().NotBeNull();
@@ -157,50 +193,14 @@ public class FileInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void IsNotReadOnly_WithWritableFile_ShouldNotThrow(FileDescription fileDescription)
+	public void NotBeReadOnly_WithWritableFile_ShouldNotThrow(FileDescription fileDescription)
 	{
 		fileDescription.IsReadOnly = false;
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
 			.With(fileDescription);
-		FileAssertions? sut = fileSystem.Should().HaveFile(fileDescription.Name).Which;
+		IFileInfo sut = fileSystem.FileInfo.New(fileDescription.Name);
 
-		sut.IsNotReadOnly();
-	}
-
-	[Theory]
-	[AutoData]
-	public void IsReadOnly_WithReadOnlyFile_ShouldNotThrow(FileDescription fileDescription)
-	{
-		fileDescription.IsReadOnly = true;
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.With(fileDescription);
-		FileAssertions? sut = fileSystem.Should().HaveFile(fileDescription.Name).Which;
-
-		sut.IsReadOnly();
-	}
-
-	[Theory]
-	[AutoData]
-	public void IsReadOnly_WithWritableFile_ShouldThrow(
-		FileDescription fileDescription,
-		string because)
-	{
-		fileDescription.IsReadOnly = false;
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.With(fileDescription);
-		FileAssertions? sut = fileSystem.Should().HaveFile(fileDescription.Name).Which;
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.IsReadOnly(because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should()
-			.Be(
-				$"Expected file \"{fileDescription.Name}\" to be read-only {because}, but it was not.");
+		sut.Should().NotBeReadOnly();
 	}
 }


### PR DESCRIPTION
In order to be able to use correct grammar, the assertions have to be split. It is now possible to call
```csharp
fileSystem.Should().HaveFile("foo.bar").Which.IsReadOnly();
```
as well as
```csharp
fileSystem.FileInfo.New("foo.bar").Should().BeReadOnly();
```

The same applies for the other methods.