### PR TITLE
coverage: add additional tests for Match

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -20,7 +20,19 @@ public class DirectoryAssertions :
 	public AndConstraint<DirectoryAssertions> HasFileMatching(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		Subject.Should().HaveFileMatching(searchPattern, because, becauseArgs);
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.ForCondition(!string.IsNullOrEmpty(searchPattern))
+			.FailWith(
+				"You can't assert a file exist in the directory if you don't pass a proper name")
+			.Then
+			.Given(() => Subject.GetFiles(searchPattern))
+			.ForCondition(fileInfos => fileInfos.Length > 0)
+			.FailWith(
+				"Expected {context} {1} to contain at least one file matching {0}{reason}, but none was found.",
+				_ => searchPattern, _ => Subject.Name);
+
 		return new AndConstraint<DirectoryAssertions>(this);
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -20,19 +20,7 @@ public class DirectoryInfoAssertions :
 	public AndConstraint<DirectoryInfoAssertions> HaveFileMatching(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		Execute.Assertion
-			.WithDefaultIdentifier(Identifier)
-			.BecauseOf(because, becauseArgs)
-			.ForCondition(!string.IsNullOrEmpty(searchPattern))
-			.FailWith(
-				"You can't assert a file exist in the directory if you don't pass a proper name")
-			.Then
-			.Given(() => Subject.GetFiles(searchPattern))
-			.ForCondition(fileInfos => fileInfos.Length > 0)
-			.FailWith(
-				"Expected {context} {1} to contain at least one file matching {0}{reason}, but none was found.",
-				_ => searchPattern, _ => Subject.Name);
-
+		new DirectoryAssertions(Subject).HasFileMatching(searchPattern, because, becauseArgs);
 		return new AndConstraint<DirectoryInfoAssertions>(this);
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
@@ -22,7 +22,15 @@ public class FileAssertions :
 	public AndConstraint<FileAssertions> IsNotReadOnly(
 		string because = "", params object[] becauseArgs)
 	{
-		Subject.Should().NotBeReadOnly(because, becauseArgs);
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.Given(() => Subject)
+			.ForCondition(fileInfo => !fileInfo.IsReadOnly)
+			.FailWith(
+				"Expected {context} {0} not to be read-only{reason}, but it was.",
+				_ => Subject.Name);
+
 		return new AndConstraint<FileAssertions>(this);
 	}
 
@@ -32,7 +40,15 @@ public class FileAssertions :
 	public AndConstraint<FileAssertions> IsReadOnly(
 		string because = "", params object[] becauseArgs)
 	{
-		Subject.Should().BeReadOnly(because, becauseArgs);
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.Given(() => Subject)
+			.ForCondition(fileInfo => fileInfo.IsReadOnly)
+			.FailWith(
+				"Expected {context} {0} to be read-only{reason}, but it was not.",
+				_ => Subject.Name);
+
 		return new AndConstraint<FileAssertions>(this);
 	}
 
@@ -42,7 +58,16 @@ public class FileAssertions :
 	public AndConstraint<FileAssertions> HasContentMatching(
 		Match pattern, string because = "", params object[] becauseArgs)
 	{
-		Subject.Should().HaveContentMatching(pattern, because, becauseArgs);
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.Given(() => Subject)
+			.ForCondition(fileInfo => pattern.Matches(
+				fileInfo.FileSystem.File.ReadAllText(fileInfo.FullName)))
+			.FailWith(
+				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
+				_ => Subject.Name, _ => pattern);
+
 		return new AndConstraint<FileAssertions>(this);
 	}
 
@@ -53,7 +78,16 @@ public class FileAssertions :
 	public AndConstraint<FileAssertions> HasContentMatching(
 		Match pattern, Encoding encoding, string because = "", params object[] becauseArgs)
 	{
-		Subject.Should().HaveContentMatching(pattern, encoding, because, becauseArgs);
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.Given(() => Subject)
+			.ForCondition(fileInfo => pattern.Matches(
+				fileInfo.FileSystem.File.ReadAllText(fileInfo.FullName, encoding)))
+			.FailWith(
+				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
+				_ => Subject.Name, _ => pattern);
+
 		return new AndConstraint<FileAssertions>(this);
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
@@ -17,38 +17,12 @@ public class FileInfoAssertions :
 	}
 
 	/// <summary>
-	///     Asserts that the current file is not read-only.
-	/// </summary>
-	public AndConstraint<FileInfoAssertions> NotBeReadOnly(
-		string because = "", params object[] becauseArgs)
-	{
-		Execute.Assertion
-			.WithDefaultIdentifier(Identifier)
-			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
-			.ForCondition(fileInfo => !fileInfo.IsReadOnly)
-			.FailWith(
-				"Expected {context} {0} not to be read-only{reason}, but it was.",
-				_ => Subject.Name);
-
-		return new AndConstraint<FileInfoAssertions>(this);
-	}
-
-	/// <summary>
 	///     Asserts that the current file is read-only.
 	/// </summary>
 	public AndConstraint<FileInfoAssertions> BeReadOnly(
 		string because = "", params object[] becauseArgs)
 	{
-		Execute.Assertion
-			.WithDefaultIdentifier(Identifier)
-			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
-			.ForCondition(fileInfo => fileInfo.IsReadOnly)
-			.FailWith(
-				"Expected {context} {0} to be read-only{reason}, but it was not.",
-				_ => Subject.Name);
-
+		new FileAssertions(Subject).IsReadOnly(because, becauseArgs);
 		return new AndConstraint<FileInfoAssertions>(this);
 	}
 
@@ -58,16 +32,7 @@ public class FileInfoAssertions :
 	public AndConstraint<FileInfoAssertions> HaveContentMatching(
 		Match pattern, string because = "", params object[] becauseArgs)
 	{
-		Execute.Assertion
-			.WithDefaultIdentifier(Identifier)
-			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
-			.ForCondition(fileInfo => pattern.Matches(
-				fileInfo.FileSystem.File.ReadAllText(fileInfo.FullName)))
-			.FailWith(
-				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
-				_ => Subject.Name, _ => pattern);
-
+		new FileAssertions(Subject).HasContentMatching(pattern, because, becauseArgs);
 		return new AndConstraint<FileInfoAssertions>(this);
 	}
 
@@ -78,16 +43,17 @@ public class FileInfoAssertions :
 	public AndConstraint<FileInfoAssertions> HaveContentMatching(
 		Match pattern, Encoding encoding, string because = "", params object[] becauseArgs)
 	{
-		Execute.Assertion
-			.WithDefaultIdentifier(Identifier)
-			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
-			.ForCondition(fileInfo => pattern.Matches(
-				fileInfo.FileSystem.File.ReadAllText(fileInfo.FullName, encoding)))
-			.FailWith(
-				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
-				_ => Subject.Name, _ => pattern);
+		new FileAssertions(Subject).HasContentMatching(pattern, encoding, because, becauseArgs);
+		return new AndConstraint<FileInfoAssertions>(this);
+	}
 
+	/// <summary>
+	///     Asserts that the current file is not read-only.
+	/// </summary>
+	public AndConstraint<FileInfoAssertions> NotBeReadOnly(
+		string because = "", params object[] becauseArgs)
+	{
+		new FileAssertions(Subject).IsNotReadOnly(because, becauseArgs);
 		return new AndConstraint<FileInfoAssertions>(this);
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileAssertionsTests.cs
@@ -116,13 +116,13 @@ public class FileAssertionsTests
 		string content = "Dans mes rêves";
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize();
-		fileSystem.File.WriteAllText(fileName, content, Encoding.ASCII);
+		fileSystem.File.WriteAllText(fileName, content, Encoding.Default);
 		FileAssertions? sut = fileSystem.Should().HaveFile(fileName).Which;
 		string pattern = content;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasContentMatching(pattern, Encoding.Default, because);
+			sut.HasContentMatching(pattern, Encoding.ASCII, because);
 		});
 
 		exception.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
@@ -153,13 +153,13 @@ public class FileInfoAssertionsTests
 		string content = "Dans mes rêves";
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize();
-		fileSystem.File.WriteAllText(fileName, content, Encoding.ASCII);
+		fileSystem.File.WriteAllText(fileName, content, Encoding.Default);
 		IFileInfo sut = fileSystem.FileInfo.New(fileName);
 		string pattern = content;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveContentMatching(pattern, Encoding.Default, because);
+			sut.Should().HaveContentMatching(pattern, Encoding.ASCII, because);
 		});
 
 		exception.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/MatchTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/MatchTests.cs
@@ -5,6 +5,18 @@ namespace Testably.Abstractions.FluentAssertions.Tests;
 
 public sealed class MatchTests
 {
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	public void ImplicitCast_FromNull_ShouldUseEmptyString(string? pattern)
+	{
+		Match match = pattern;
+
+		match.Matches("").Should().BeTrue();
+		match.Matches(" ").Should().BeFalse();
+		match.ToString().Should().Be("");
+	}
+
 	[Fact]
 	public void Wildcard_MatchesNull_ShouldReturnFalse()
 	{
@@ -32,6 +44,21 @@ public sealed class MatchTests
 		bool matches = match.Matches(testInput);
 
 		matches.Should().Be(expectedResult,
-			$"wildcard '{wildcard.Replace("$", "$$")}' should match '{testInput}'");
+			$"wildcard '{wildcard.Replace("$", "$$")}' should{(expectedResult ? "" : " not")} match '{testInput}'");
+	}
+
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void Wildcard_WithIgnoreCase_ShouldConsiderFlag(
+		bool ignoreCase)
+	{
+		bool expectedResult = ignoreCase;
+		Match match = Match.Wildcard("foo", ignoreCase);
+
+		bool matches = match.Matches("FOO");
+
+		matches.Should().Be(expectedResult,
+			$"wildcard 'foo' should{(expectedResult ? "" : " not")} match 'FOO' while ignoreCase:{ignoreCase}");
 	}
 }


### PR DESCRIPTION
Add two additional tests for `Match`.

Also move the implementation to `FileAssertions` and `DirectoryAssertions` respectively.