### PR TITLE
feat: support nullable IFileSystemInfo assertions

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -4,12 +4,12 @@
 ///     Assertions on <see cref="IDirectoryInfo" />.
 /// </summary>
 public class DirectoryAssertions :
-	ReferenceTypeAssertions<IDirectoryInfo, DirectoryAssertions>
+	ReferenceTypeAssertions<IDirectoryInfo?, DirectoryAssertions>
 {
 	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
 	protected override string Identifier => "directory";
 
-	internal DirectoryAssertions(IDirectoryInfo instance)
+	internal DirectoryAssertions(IDirectoryInfo? instance)
 		: base(instance)
 	{
 	}
@@ -19,19 +19,30 @@ public class DirectoryAssertions :
 	/// </summary>
 	public AndConstraint<DirectoryAssertions> HasFileMatching(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
+		=> HasFilesMatching(searchPattern, 1, because, becauseArgs);
+
+	/// <summary>
+	///     Asserts that the current directory has at least <paramref name="minimumCount"/> files which match the <paramref name="searchPattern" />.
+	/// </summary>
+	public AndConstraint<DirectoryAssertions> HasFilesMatching(
+		string searchPattern = "*", int minimumCount = 1, string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert a directory having files if the DirectoryInfo is null")
+			.Then
 			.ForCondition(!string.IsNullOrEmpty(searchPattern))
 			.FailWith(
-				"You can't assert a file exist in the directory if you don't pass a proper name")
+				"You can't assert a directory having files if you don't pass a proper name")
 			.Then
-			.Given(() => Subject.GetFiles(searchPattern))
-			.ForCondition(fileInfos => fileInfos.Length > 0)
+			.Given(() => Subject!)
+			.ForCondition(directoryInfo => directoryInfo.GetFiles(searchPattern).Length > 0)
 			.FailWith(
-				"Expected {context} {1} to contain at least one file matching {0}{reason}, but none was found.",
-				_ => searchPattern, _ => Subject.Name);
+				$"Expected {{context}} {{1}} to contain at least {(minimumCount == 1 ? "one file" : $"{minimumCount} files")} matching {{0}}{{reason}}, but none was found.",
+				_ => searchPattern, directoryInfo => directoryInfo.Name);
 
 		return new AndConstraint<DirectoryAssertions>(this);
 	}

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -9,7 +9,7 @@ public class DirectoryInfoAssertions :
 	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
 	protected override string Identifier => "directory";
 
-	internal DirectoryInfoAssertions(IDirectoryInfo instance)
+	internal DirectoryInfoAssertions(IDirectoryInfo? instance)
 		: base(instance)
 	{
 	}

--- a/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
@@ -7,12 +7,12 @@ namespace Testably.Abstractions.FluentAssertions;
 ///     Assertions on <see cref="IFileInfo" />.
 /// </summary>
 public class FileAssertions :
-	ReferenceTypeAssertions<IFileInfo, FileAssertions>
+	ReferenceTypeAssertions<IFileInfo?, FileAssertions>
 {
 	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
 	protected override string Identifier => "file";
 
-	internal FileAssertions(IFileInfo instance)
+	internal FileAssertions(IFileInfo? instance)
 		: base(instance)
 	{
 	}
@@ -26,13 +26,17 @@ public class FileAssertions :
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert the content of a file if the FileInfo is null")
+			.Then
+			.Given(() => Subject!)
 			.ForCondition(fileInfo => fileInfo.FileSystem.File
 				.ReadAllBytes(fileInfo.FullName)
 				.SequenceEqual(bytes))
 			.FailWith(
 				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
-				_ => Subject.Name, _ => bytes);
+				fileInfo => fileInfo.Name, _ => bytes);
 
 		return new AndConstraint<FileAssertions>(this);
 	}
@@ -46,12 +50,16 @@ public class FileAssertions :
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert the content of a file if the FileInfo is null")
+			.Then
+			.Given(() => Subject!)
 			.ForCondition(fileInfo => pattern.Matches(
 				fileInfo.FileSystem.File.ReadAllText(fileInfo.FullName)))
 			.FailWith(
 				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
-				_ => Subject.Name, _ => pattern);
+				fileInfo => fileInfo.Name, _ => pattern);
 
 		return new AndConstraint<FileAssertions>(this);
 	}
@@ -66,12 +74,16 @@ public class FileAssertions :
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert the content of a file if the FileInfo is null")
+			.Then
+			.Given(() => Subject!)
 			.ForCondition(fileInfo => pattern.Matches(
 				fileInfo.FileSystem.File.ReadAllText(fileInfo.FullName, encoding)))
 			.FailWith(
 				"Expected {context} {0} to match '{1}'{reason}, but it did not.",
-				_ => Subject.Name, _ => pattern);
+				fileInfo => fileInfo.Name, _ => pattern);
 
 		return new AndConstraint<FileAssertions>(this);
 	}
@@ -85,11 +97,15 @@ public class FileAssertions :
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert that the file is not read-only if the FileInfo is null")
+			.Then
+			.Given(() => Subject!)
 			.ForCondition(fileInfo => !fileInfo.IsReadOnly)
 			.FailWith(
 				"Expected {context} {0} not to be read-only{reason}, but it was.",
-				_ => Subject.Name);
+				fileInfo => fileInfo.Name);
 
 		return new AndConstraint<FileAssertions>(this);
 	}
@@ -103,11 +119,15 @@ public class FileAssertions :
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert that the file is read-only if the FileInfo is null")
+			.Then
+			.Given(() => Subject!)
 			.ForCondition(fileInfo => fileInfo.IsReadOnly)
 			.FailWith(
 				"Expected {context} {0} to be read-only{reason}, but it was not.",
-				_ => Subject.Name);
+				fileInfo => fileInfo.Name);
 
 		return new AndConstraint<FileAssertions>(this);
 	}

--- a/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
@@ -11,7 +11,7 @@ public class FileInfoAssertions :
 	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
 	protected override string Identifier => "file";
 
-	internal FileInfoAssertions(IFileInfo instance)
+	internal FileInfoAssertions(IFileInfo? instance)
 		: base(instance)
 	{
 	}

--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemExtensions.cs
@@ -9,14 +9,14 @@ public static class FileSystemExtensions
 	///     Returns a <see cref="DirectoryAssertions" /> object that can be used to
 	///     assert the current <see cref="IDirectoryInfo" />.
 	/// </summary>
-	public static DirectoryInfoAssertions Should(this IDirectoryInfo instance)
+	public static DirectoryInfoAssertions Should(this IDirectoryInfo? instance)
 		=> new(instance);
 
 	/// <summary>
 	///     Returns a <see cref="FileAssertions" /> object that can be used to
 	///     assert the current <see cref="IFileInfo" />.
 	/// </summary>
-	public static FileInfoAssertions Should(this IFileInfo instance)
+	public static FileInfoAssertions Should(this IFileInfo? instance)
 		=> new(instance);
 
 	/// <summary>

--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemInfoAssertions.cs
@@ -5,14 +5,14 @@
 /// </summary>
 public abstract class
 	FileSystemInfoAssertions<TFileSystemInfo, TAssertion>
-	: ReferenceTypeAssertions<TFileSystemInfo, TAssertion>
+	: ReferenceTypeAssertions<TFileSystemInfo?, TAssertion>
 	where TFileSystemInfo : IFileSystemInfo
-	where TAssertion : ReferenceTypeAssertions<TFileSystemInfo, TAssertion>
+	where TAssertion : ReferenceTypeAssertions<TFileSystemInfo?, TAssertion>
 {
 	/// <summary>
 	///     Initializes a new instance of <see cref="FileSystemInfoAssertions{TFileSystemInfo,TAssertion}" />
 	/// </summary>
-	protected FileSystemInfoAssertions(TFileSystemInfo subject) : base(subject)
+	protected FileSystemInfoAssertions(TFileSystemInfo? subject) : base(subject)
 	{
 	}
 
@@ -25,12 +25,15 @@ public abstract class
 		Execute.Assertion
 			.WithDefaultIdentifier(Identifier)
 			.BecauseOf(because, becauseArgs)
-			.Given(() => Subject)
+			.ForCondition(Subject != null)
+			.FailWith("You can't assert that the {context} exists if it is null")
+			.Then
+			.Given(() => Subject!)
 			.ForCondition(fileSystemInfo => fileSystemInfo.Exists)
 			.FailWith(
 				"Expected {context} {0} to exist{reason}, but it did not.",
-				_ => Subject.Name);
+				fileSystemInfo => fileSystemInfo.Name);
 
-		return new AndConstraint<TFileSystemInfo>(Subject);
+		return new AndConstraint<TFileSystemInfo>(Subject!);
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
@@ -32,6 +32,22 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
+	public void HaveFileMatching_Null_ShouldThrow(string because)
+	{
+		IDirectoryInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFileMatching(because: because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
 	public void HaveFileMatching_WithMatchingFile_ShouldNotThrow(
 		string directoryName,
 		string fileName)

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
@@ -14,6 +14,22 @@ public class FileInfoAssertionsTests
 {
 	[Theory]
 	[AutoData]
+	public void BeReadOnly_Null_ShouldThrow(string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().BeReadOnly(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
 	public void BeReadOnly_WithReadOnlyFile_ShouldNotThrow(FileDescription fileDescription)
 	{
 		fileDescription.IsReadOnly = true;
@@ -59,6 +75,22 @@ public class FileInfoAssertionsTests
 		IFileInfo sut = fileSystem.FileInfo.New(fileName);
 
 		sut.Should().HaveContent(bytes);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveContent_Bytes_Null_ShouldThrow(byte[] bytes, string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveContent(bytes, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
 	}
 
 	[Theory]
@@ -183,6 +215,39 @@ public class FileInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
+	public void HaveContent_StringContent_Null_ShouldThrow(string content, string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveContent(content, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveContent_StringContent_WithEncoding_Null_ShouldThrow(
+		Encoding encoding, string content, string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveContent(content, encoding, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
 	public void HaveContent_WithEncodingMismatch_ShouldThrow(
 		string fileName, string because)
 	{
@@ -202,6 +267,22 @@ public class FileInfoAssertionsTests
 		exception!.Message.Should()
 			.Be(
 				$"Expected file \"{fileName}\" to match '{pattern}' {because}, but it did not.");
+	}
+
+	[Theory]
+	[AutoData]
+	public void NotBeReadOnly_Null_ShouldThrow(string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().NotBeReadOnly(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemInfoAssertionsTests.cs
@@ -11,6 +11,22 @@ public class FileSystemInfoAssertionsTests
 {
 	[Theory]
 	[AutoData]
+	public void Exist_ForDirectoryInfo_Null_ShouldThrow(string because)
+	{
+		IDirectoryInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().Exist(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
 	public void Exist_ForDirectoryInfo_WithCorrectDirectory_ShouldNotThrow(string directoryName)
 	{
 		MockFileSystem fileSystem = new();
@@ -61,6 +77,22 @@ public class FileSystemInfoAssertionsTests
 		exception.Should().NotBeNull();
 		exception!.Message.Should()
 			.Be($"Expected directory \"{fileName}\" to exist {because}, but it did not.");
+	}
+
+	[Theory]
+	[AutoData]
+	public void Exist_ForFileInfo_Null_ShouldThrow(string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().Exist(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
 	}
 
 	[Theory]


### PR DESCRIPTION
Make IDirectoryInfo and IFileInfo nullable in the assertions, so that also `null` can be asserted.