### PR TITLE
feat: add assertions for HasSingleFileMatching

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -1,4 +1,6 @@
-﻿namespace Testably.Abstractions.FluentAssertions;
+﻿using System.Linq;
+
+namespace Testably.Abstractions.FluentAssertions;
 
 /// <summary>
 ///     Assertions on <see cref="IDirectoryInfo" />.
@@ -12,6 +14,37 @@ public class DirectoryAssertions :
 	internal DirectoryAssertions(IDirectoryInfo? instance)
 		: base(instance)
 	{
+	}
+
+	/// <summary>
+	///     Asserts that the directory contains exactly one file matching the given <paramref name="searchPattern"/>.
+	/// </summary>
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HasSingleFile(
+		string searchPattern = "*", string because = "", params object[] becauseArgs)
+	{
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert a directory having a given file if it is null")
+			.Then
+			.ForCondition(!string.IsNullOrEmpty(searchPattern))
+			.FailWith(
+				"You can't assert a directory having a given file if you don't pass a proper name")
+			.Then
+			.Given(() => Subject!)
+			.ForCondition(directoryInfo
+				=> directoryInfo.GetFiles(searchPattern).Length == 1)
+			.FailWith(
+				"Expected {context} {1} to contain exactly one file matching {0}{reason}, but found {2}.",
+				_ => searchPattern,
+				directoryInfo => directoryInfo.Name,
+				directoryInfo => directoryInfo.GetFiles(searchPattern).Length);
+		
+		return new AndWhichConstraint<FileSystemAssertions, FileAssertions>(
+			new FileSystemAssertions(Subject!.FileSystem),
+			new FileAssertions(Subject!.GetFiles(searchPattern).Single()));
 	}
 
 	/// <summary>
@@ -47,7 +80,8 @@ public class DirectoryAssertions :
 				=> directoryInfo.GetFiles(searchPattern).Length >= minimumCount)
 			.FailWith(
 				$"Expected {{context}} {{1}} to contain at least {(minimumCount == 1 ? "one file" : $"{minimumCount} files")} matching {{0}}{{reason}}, but {(minimumCount == 1 ? "none was" : "only {2} were")} found.",
-				_ => searchPattern, directoryInfo => directoryInfo.Name,
+				_ => searchPattern,
+				directoryInfo => directoryInfo.Name,
 				directoryInfo => directoryInfo.GetFiles(searchPattern).Length);
 
 		return new AndConstraint<DirectoryAssertions>(this);

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -19,7 +19,7 @@ public class DirectoryAssertions :
 	/// <summary>
 	///     Asserts that the directory contains exactly one file matching the given <paramref name="searchPattern"/>.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HasSingleFile(
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HasSingleFileMatching(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -30,6 +30,6 @@ public class DirectoryInfoAssertions :
 	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HaveSingleFile(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		return new DirectoryAssertions(Subject).HasSingleFile(searchPattern, because, becauseArgs);
+		return new DirectoryAssertions(Subject).HasSingleFileMatching(searchPattern, because, becauseArgs);
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -23,4 +23,13 @@ public class DirectoryInfoAssertions :
 		new DirectoryAssertions(Subject).HasFileMatching(searchPattern, because, becauseArgs);
 		return new AndConstraint<DirectoryInfoAssertions>(this);
 	}
+
+	/// <summary>
+	///     Asserts that the directory contains exactly one file matching the given <paramref name="searchPattern" />.
+	/// </summary>
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HaveSingleFile(
+		string searchPattern = "*", string because = "", params object[] becauseArgs)
+	{
+		return new DirectoryAssertions(Subject).HasSingleFile(searchPattern, because, becauseArgs);
+	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
@@ -84,4 +84,104 @@ public class DirectoryInfoAssertionsTests
 			.Be(
 				$"Expected directory \"{directoryName}\" to contain at least one file matching \"{fileName}\" {because}, but none was found.");
 	}
+
+	[Theory]
+	[InlineAutoData(null)]
+	[InlineAutoData("")]
+	public void HaveSingleFile_InvalidFileName_ShouldThrow(string? invalidFileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory("foo");
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New("foo");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveSingleFile(invalidFileName!, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().NotBeNullOrEmpty();
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveSingleFile_Null_ShouldThrow(string because)
+	{
+		IDirectoryInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveSingleFile(because: because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveSingleFile_WithMatchingFile_ShouldNotThrow(
+		string directoryName,
+		string fileName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile(fileName));
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+
+		sut.Should().HaveSingleFile(fileName);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveSingleFile_WithMultipleMatchingFile_ShouldThrow(
+		string directoryName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile("file1.txt")
+				.WithFile("file2.txt"));
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveSingleFile("file*.txt", because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected directory \"{directoryName}\" to contain exactly one file matching \"file*.txt\" {because}, but found 2.");
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveSingleFile_WithoutMatchingFile_ShouldThrow(
+		string directoryName,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile("not-matching-file"));
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveSingleFile(fileName, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected directory \"{directoryName}\" to contain exactly one file matching \"{fileName}\" {because}, but found 0.");
+	}
 }


### PR DESCRIPTION
These assertions return a `AndWhichConstraint<FileSystemAssertions, FileAssertions>` so that further assertions on the file can be added.