### PR TITLE
refactor: simplify assertion names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This library is an extension to [FluentAssertions](https://github.com/fluentasse
    or
    ```csharp
    IDirectoryInfo directoryInfo = fileSystem.DirectoryInfo.New(".");
-   directoryInfo.Should().HaveSingleDirectory("foo");
+   directoryInfo.Should().HaveDirectory("foo");
    ```
 
 3. Verify, that the file "foo.txt" has text content "bar":

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -57,46 +57,6 @@ public class DirectoryAssertions :
 		=> HasDirectories(searchPattern, 1, because, becauseArgs);
 
 	/// <summary>
-	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
-	/// </summary>
-	public AndConstraint<DirectoryAssertions> HasFiles(
-		string searchPattern = "*", string because = "", params object[] becauseArgs)
-		=> HasFiles(searchPattern, 1, because, becauseArgs);
-
-	/// <summary>
-	///     Asserts that the current directory has at least <paramref name="minimumCount" /> files which match the
-	///     <paramref name="searchPattern" />.
-	/// </summary>
-	public AndConstraint<DirectoryAssertions> HasFiles(
-		string searchPattern,
-		int minimumCount,
-		string because = "",
-		params object[] becauseArgs)
-	{
-		Execute.Assertion
-			.WithDefaultIdentifier(Identifier)
-			.BecauseOf(because, becauseArgs)
-			.ForCondition(Subject != null)
-			.FailWith(
-				"You can't assert a directory having files if the DirectoryInfo is null.")
-			.Then
-			.ForCondition(!string.IsNullOrEmpty(searchPattern))
-			.FailWith(
-				"You can't assert a directory having files if you don't pass a proper search pattern.")
-			.Then
-			.Given(() => Subject!)
-			.ForCondition(directoryInfo
-				=> directoryInfo.GetFiles(searchPattern).Length >= minimumCount)
-			.FailWith(
-				$"Expected {{context}} {{1}} to contain at least {(minimumCount == 1 ? "one file" : $"{minimumCount} files")} matching {{0}}{{reason}}, but {(minimumCount == 1 ? "none was" : "only {2} were")} found.",
-				_ => searchPattern,
-				directoryInfo => directoryInfo.Name,
-				directoryInfo => directoryInfo.GetFiles(searchPattern).Length);
-
-		return new AndConstraint<DirectoryAssertions>(this);
-	}
-
-	/// <summary>
 	///     Asserts that the directory contains exactly one directory matching the given <paramref name="searchPattern" />.
 	/// </summary>
 	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HasDirectory(
@@ -156,5 +116,45 @@ public class DirectoryAssertions :
 		return new AndWhichConstraint<FileSystemAssertions, FileAssertions>(
 			new FileSystemAssertions(Subject!.FileSystem),
 			new FileAssertions(Subject!.GetFiles(searchPattern).Single()));
+	}
+
+	/// <summary>
+	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
+	/// </summary>
+	public AndConstraint<DirectoryAssertions> HasFiles(
+		string searchPattern = "*", string because = "", params object[] becauseArgs)
+		=> HasFiles(searchPattern, 1, because, becauseArgs);
+
+	/// <summary>
+	///     Asserts that the current directory has at least <paramref name="minimumCount" /> files which match the
+	///     <paramref name="searchPattern" />.
+	/// </summary>
+	public AndConstraint<DirectoryAssertions> HasFiles(
+		string searchPattern,
+		int minimumCount,
+		string because = "",
+		params object[] becauseArgs)
+	{
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.ForCondition(Subject != null)
+			.FailWith(
+				"You can't assert a directory having files if the DirectoryInfo is null.")
+			.Then
+			.ForCondition(!string.IsNullOrEmpty(searchPattern))
+			.FailWith(
+				"You can't assert a directory having files if you don't pass a proper search pattern.")
+			.Then
+			.Given(() => Subject!)
+			.ForCondition(directoryInfo
+				=> directoryInfo.GetFiles(searchPattern).Length >= minimumCount)
+			.FailWith(
+				$"Expected {{context}} {{1}} to contain at least {(minimumCount == 1 ? "one file" : $"{minimumCount} files")} matching {{0}}{{reason}}, but {(minimumCount == 1 ? "none was" : "only {2} were")} found.",
+				_ => searchPattern,
+				directoryInfo => directoryInfo.Name,
+				directoryInfo => directoryInfo.GetFiles(searchPattern).Length);
+
+		return new AndConstraint<DirectoryAssertions>(this);
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryAssertions.cs
@@ -20,9 +20,9 @@ public class DirectoryAssertions :
 	///     Asserts that the current directory has at least <paramref name="minimumCount" /> directories which match the
 	///     <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryAssertions> HasDirectoriesMatching(
-		string searchPattern = "*",
-		int minimumCount = 1,
+	public AndConstraint<DirectoryAssertions> HasDirectories(
+		string searchPattern,
+		int minimumCount,
 		string because = "",
 		params object[] becauseArgs)
 	{
@@ -52,24 +52,24 @@ public class DirectoryAssertions :
 	/// <summary>
 	///     Asserts that the current directory has at least one directory which matches the <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryAssertions> HasDirectoryMatching(
+	public AndConstraint<DirectoryAssertions> HasDirectories(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
-		=> HasDirectoriesMatching(searchPattern, 1, because, becauseArgs);
+		=> HasDirectories(searchPattern, 1, because, becauseArgs);
 
 	/// <summary>
 	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryAssertions> HasFileMatching(
+	public AndConstraint<DirectoryAssertions> HasFiles(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
-		=> HasFilesMatching(searchPattern, 1, because, becauseArgs);
+		=> HasFiles(searchPattern, 1, because, becauseArgs);
 
 	/// <summary>
 	///     Asserts that the current directory has at least <paramref name="minimumCount" /> files which match the
 	///     <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryAssertions> HasFilesMatching(
-		string searchPattern = "*",
-		int minimumCount = 1,
+	public AndConstraint<DirectoryAssertions> HasFiles(
+		string searchPattern,
+		int minimumCount,
 		string because = "",
 		params object[] becauseArgs)
 	{
@@ -99,7 +99,7 @@ public class DirectoryAssertions :
 	/// <summary>
 	///     Asserts that the directory contains exactly one directory matching the given <paramref name="searchPattern" />.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HasSingleDirectoryMatching(
+	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HasDirectory(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion
@@ -130,7 +130,7 @@ public class DirectoryAssertions :
 	/// <summary>
 	///     Asserts that the directory contains exactly one file matching the given <paramref name="searchPattern" />.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HasSingleFileMatching(
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HasFile(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
 		Execute.Assertion

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -17,40 +17,40 @@ public class DirectoryInfoAssertions :
 	/// <summary>
 	///     Asserts that the current directory has at least one directory which matches the <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryInfoAssertions> HaveDirectoryMatching(
+	public AndConstraint<DirectoryInfoAssertions> HaveDirectories(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		new DirectoryAssertions(Subject).HasDirectoryMatching(searchPattern, because, becauseArgs);
+		new DirectoryAssertions(Subject).HasDirectories(searchPattern, because, becauseArgs);
 		return new AndConstraint<DirectoryInfoAssertions>(this);
 	}
 
 	/// <summary>
 	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
 	/// </summary>
-	public AndConstraint<DirectoryInfoAssertions> HaveFileMatching(
+	public AndConstraint<DirectoryInfoAssertions> HaveFiles(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		new DirectoryAssertions(Subject).HasFileMatching(searchPattern, because, becauseArgs);
+		new DirectoryAssertions(Subject).HasFiles(searchPattern, because, becauseArgs);
 		return new AndConstraint<DirectoryInfoAssertions>(this);
 	}
 
 	/// <summary>
 	///     Asserts that the directory contains exactly one directory matching the given <paramref name="searchPattern" />.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HaveSingleDirectory(
+	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HaveDirectory(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		return new DirectoryAssertions(Subject).HasSingleDirectoryMatching(searchPattern, because,
+		return new DirectoryAssertions(Subject).HasDirectory(searchPattern, because,
 			becauseArgs);
 	}
 
 	/// <summary>
 	///     Asserts that the directory contains exactly one file matching the given <paramref name="searchPattern" />.
 	/// </summary>
-	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HaveSingleFile(
+	public AndWhichConstraint<FileSystemAssertions, FileAssertions> HaveFile(
 		string searchPattern = "*", string because = "", params object[] becauseArgs)
 	{
-		return new DirectoryAssertions(Subject).HasSingleFileMatching(searchPattern, because,
+		return new DirectoryAssertions(Subject).HasFile(searchPattern, because,
 			becauseArgs);
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/DirectoryInfoAssertions.cs
@@ -25,16 +25,6 @@ public class DirectoryInfoAssertions :
 	}
 
 	/// <summary>
-	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
-	/// </summary>
-	public AndConstraint<DirectoryInfoAssertions> HaveFiles(
-		string searchPattern = "*", string because = "", params object[] becauseArgs)
-	{
-		new DirectoryAssertions(Subject).HasFiles(searchPattern, because, becauseArgs);
-		return new AndConstraint<DirectoryInfoAssertions>(this);
-	}
-
-	/// <summary>
 	///     Asserts that the directory contains exactly one directory matching the given <paramref name="searchPattern" />.
 	/// </summary>
 	public AndWhichConstraint<FileSystemAssertions, DirectoryAssertions> HaveDirectory(
@@ -52,5 +42,15 @@ public class DirectoryInfoAssertions :
 	{
 		return new DirectoryAssertions(Subject).HasFile(searchPattern, because,
 			becauseArgs);
+	}
+
+	/// <summary>
+	///     Asserts that the current directory has at least one file which matches the <paramref name="searchPattern" />.
+	/// </summary>
+	public AndConstraint<DirectoryInfoAssertions> HaveFiles(
+		string searchPattern = "*", string because = "", params object[] becauseArgs)
+	{
+		new DirectoryAssertions(Subject).HasFiles(searchPattern, because, becauseArgs);
+		return new AndConstraint<DirectoryInfoAssertions>(this);
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryAssertionsTests.cs
@@ -9,38 +9,6 @@ namespace Testably.Abstractions.FluentAssertions.Tests;
 public class DirectoryAssertionsTests
 {
 	[Theory]
-	[InlineAutoData(3, 5)]
-	[InlineAutoData(1, 2)]
-	public void HasDirectories_WithoutTooLittleDirectories_ShouldThrow(
-		int matchingCount,
-		int expectedCount,
-		string directoryName,
-		string directoryNamePrefix,
-		string because)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory(directoryName);
-		for (int i = 0; i < matchingCount; i++)
-		{
-			fileSystem.Directory.CreateDirectory(
-				fileSystem.Path.Combine(directoryName, $"{directoryNamePrefix}-{i}"));
-		}
-
-		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.HasDirectories($"{directoryNamePrefix}*", expectedCount, because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should()
-			.Be(
-				$"Expected directory \"{directoryName}\" to contain at least {expectedCount} directories matching \"{directoryNamePrefix}*\" {because}, but only {matchingCount} were found.");
-	}
-
-	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
 	public void HasDirectories_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
@@ -101,72 +69,13 @@ public class DirectoryAssertionsTests
 	}
 
 	[Theory]
-	[InlineAutoData(null)]
-	[InlineAutoData("")]
-	public void HasFiles_InvalidFileName_ShouldThrow(string? invalidFileName, string because)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory("foo");
-		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory("foo").Which;
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.HasFiles(invalidFileName!, because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should().NotBeNullOrEmpty();
-		exception.Message.Should().NotContain(because);
-	}
-
-	[Theory]
-	[AutoData]
-	public void HasFiles_WithMatchingFile_ShouldNotThrow(
-		string directoryName,
-		string fileName)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory(directoryName).Initialized(d => d
-				.WithFile(fileName));
-		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
-
-		sut.HasFiles(fileName);
-	}
-
-	[Theory]
-	[AutoData]
-	public void HasFiles_WithoutMatchingFile_ShouldThrow(
-		string directoryName,
-		string fileName,
-		string because)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory(directoryName).Initialized(d => d
-				.WithFile("not-matching-file"));
-		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.HasFiles(fileName, because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should()
-			.Be(
-				$"Expected directory \"{directoryName}\" to contain at least one file matching \"{fileName}\" {because}, but none was found.");
-	}
-
-	[Theory]
 	[InlineAutoData(3, 5)]
 	[InlineAutoData(1, 2)]
-	public void HasFiles_WithoutTooLittleFiles_ShouldThrow(
+	public void HasDirectories_WithoutTooLittleDirectories_ShouldThrow(
 		int matchingCount,
 		int expectedCount,
 		string directoryName,
-		string fileNamePrefix,
+		string directoryNamePrefix,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -174,22 +83,21 @@ public class DirectoryAssertionsTests
 			.WithSubdirectory(directoryName);
 		for (int i = 0; i < matchingCount; i++)
 		{
-			fileSystem.File.WriteAllText(
-				fileSystem.Path.Combine(directoryName, $"{fileNamePrefix}-{i}.txt"),
-				"some content");
+			fileSystem.Directory.CreateDirectory(
+				fileSystem.Path.Combine(directoryName, $"{directoryNamePrefix}-{i}"));
 		}
 
 		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasFiles($"{fileNamePrefix}*", expectedCount, because);
+			sut.HasDirectories($"{directoryNamePrefix}*", expectedCount, because);
 		});
 
 		exception.Should().NotBeNull();
 		exception!.Message.Should()
 			.Be(
-				$"Expected directory \"{directoryName}\" to contain at least {expectedCount} files matching \"{fileNamePrefix}*\" {because}, but only {matchingCount} were found.");
+				$"Expected directory \"{directoryName}\" to contain at least {expectedCount} directories matching \"{directoryNamePrefix}*\" {because}, but only {matchingCount} were found.");
 	}
 
 	[Theory]
@@ -361,5 +269,97 @@ public class DirectoryAssertionsTests
 		exception!.Message.Should()
 			.Be(
 				$"Expected directory \"{directoryName}\" to contain exactly one file matching \"{fileName}\" {because}, but found 0.");
+	}
+
+	[Theory]
+	[InlineAutoData(null)]
+	[InlineAutoData("")]
+	public void HasFiles_InvalidFileName_ShouldThrow(string? invalidFileName, string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory("foo");
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory("foo").Which;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.HasFiles(invalidFileName!, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().NotBeNullOrEmpty();
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HasFiles_WithMatchingFile_ShouldNotThrow(
+		string directoryName,
+		string fileName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile(fileName));
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
+
+		sut.HasFiles(fileName);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HasFiles_WithoutMatchingFile_ShouldThrow(
+		string directoryName,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile("not-matching-file"));
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.HasFiles(fileName, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected directory \"{directoryName}\" to contain at least one file matching \"{fileName}\" {because}, but none was found.");
+	}
+
+	[Theory]
+	[InlineAutoData(3, 5)]
+	[InlineAutoData(1, 2)]
+	public void HasFiles_WithoutTooLittleFiles_ShouldThrow(
+		int matchingCount,
+		int expectedCount,
+		string directoryName,
+		string fileNamePrefix,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName);
+		for (int i = 0; i < matchingCount; i++)
+		{
+			fileSystem.File.WriteAllText(
+				fileSystem.Path.Combine(directoryName, $"{fileNamePrefix}-{i}.txt"),
+				"some content");
+		}
+
+		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.HasFiles($"{fileNamePrefix}*", expectedCount, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected directory \"{directoryName}\" to contain at least {expectedCount} files matching \"{fileNamePrefix}*\" {because}, but only {matchingCount} were found.");
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryAssertionsTests.cs
@@ -11,7 +11,7 @@ public class DirectoryAssertionsTests
 	[Theory]
 	[InlineAutoData(3, 5)]
 	[InlineAutoData(1, 2)]
-	public void HasDirectoriesMatching_WithoutTooLittleDirectories_ShouldThrow(
+	public void HasDirectories_WithoutTooLittleDirectories_ShouldThrow(
 		int matchingCount,
 		int expectedCount,
 		string directoryName,
@@ -31,7 +31,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasDirectoriesMatching($"{directoryNamePrefix}*", expectedCount, because);
+			sut.HasDirectories($"{directoryNamePrefix}*", expectedCount, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -43,7 +43,7 @@ public class DirectoryAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HasDirectoryMatching_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
+	public void HasDirectories_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -53,7 +53,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasDirectoryMatching(invalidDirectoryName!, because);
+			sut.HasDirectories(invalidDirectoryName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -63,7 +63,7 @@ public class DirectoryAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HasDirectoryMatching_WithMatchingDirectory_ShouldNotThrow(
+	public void HasDirectories_WithMatchingDirectory_ShouldNotThrow(
 		string directoryName,
 		string subdirectoryName)
 	{
@@ -73,12 +73,12 @@ public class DirectoryAssertionsTests
 				.WithSubdirectory(subdirectoryName));
 		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
-		sut.HasDirectoryMatching(subdirectoryName);
+		sut.HasDirectories(subdirectoryName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HasDirectoryMatching_WithoutMatchingDirectory_ShouldThrow(
+	public void HasDirectories_WithoutMatchingDirectory_ShouldThrow(
 		string directoryName,
 		string subdirectoryName,
 		string because)
@@ -91,7 +91,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasDirectoryMatching(subdirectoryName, because);
+			sut.HasDirectories(subdirectoryName, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -103,7 +103,7 @@ public class DirectoryAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HasFileMatching_InvalidFileName_ShouldThrow(string? invalidFileName, string because)
+	public void HasFiles_InvalidFileName_ShouldThrow(string? invalidFileName, string because)
 	{
 		MockFileSystem fileSystem = new();
 		fileSystem.Initialize()
@@ -112,7 +112,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasFileMatching(invalidFileName!, because);
+			sut.HasFiles(invalidFileName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -122,7 +122,7 @@ public class DirectoryAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HasFileMatching_WithMatchingFile_ShouldNotThrow(
+	public void HasFiles_WithMatchingFile_ShouldNotThrow(
 		string directoryName,
 		string fileName)
 	{
@@ -132,12 +132,12 @@ public class DirectoryAssertionsTests
 				.WithFile(fileName));
 		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
-		sut.HasFileMatching(fileName);
+		sut.HasFiles(fileName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HasFileMatching_WithoutMatchingFile_ShouldThrow(
+	public void HasFiles_WithoutMatchingFile_ShouldThrow(
 		string directoryName,
 		string fileName,
 		string because)
@@ -150,7 +150,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasFileMatching(fileName, because);
+			sut.HasFiles(fileName, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -162,7 +162,7 @@ public class DirectoryAssertionsTests
 	[Theory]
 	[InlineAutoData(3, 5)]
 	[InlineAutoData(1, 2)]
-	public void HasFilesMatching_WithoutTooLittleFiles_ShouldThrow(
+	public void HasFiles_WithoutTooLittleFiles_ShouldThrow(
 		int matchingCount,
 		int expectedCount,
 		string directoryName,
@@ -183,7 +183,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasFilesMatching($"{fileNamePrefix}*", expectedCount, because);
+			sut.HasFiles($"{fileNamePrefix}*", expectedCount, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -195,7 +195,7 @@ public class DirectoryAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HasSingleDirectoryMatching_InvalidDirectoryName_ShouldThrow(
+	public void HasDirectory_InvalidDirectoryName_ShouldThrow(
 		string? invalidDirectoryName,
 		string because)
 	{
@@ -206,7 +206,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasSingleDirectoryMatching(invalidDirectoryName!, because);
+			sut.HasDirectory(invalidDirectoryName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -216,7 +216,7 @@ public class DirectoryAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HasSingleDirectoryMatching_WithMatchingDirectory_ShouldNotThrow(
+	public void HasDirectory_WithMatchingDirectory_ShouldNotThrow(
 		string directoryName,
 		string subdirectoryName)
 	{
@@ -226,12 +226,12 @@ public class DirectoryAssertionsTests
 				.WithSubdirectory(subdirectoryName));
 		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
-		sut.HasSingleDirectoryMatching(subdirectoryName);
+		sut.HasDirectory(subdirectoryName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HasSingleDirectoryMatching_WithMultipleMatchingDirectory_ShouldThrow(
+	public void HasDirectory_WithMultipleMatchingDirectory_ShouldThrow(
 		string directoryName,
 		string subdirectoryName,
 		string because)
@@ -245,7 +245,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasSingleDirectoryMatching($"{subdirectoryName}*", because);
+			sut.HasDirectory($"{subdirectoryName}*", because);
 		});
 
 		exception.Should().NotBeNull();
@@ -256,7 +256,7 @@ public class DirectoryAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HasSingleDirectoryMatching_WithoutMatchingDirectory_ShouldThrow(
+	public void HasDirectory_WithoutMatchingDirectory_ShouldThrow(
 		string directoryName,
 		string subdirectoryName,
 		string because)
@@ -269,7 +269,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasSingleDirectoryMatching(subdirectoryName, because);
+			sut.HasDirectory(subdirectoryName, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -281,7 +281,7 @@ public class DirectoryAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HasSingleFileMatching_InvalidFileName_ShouldThrow(string? invalidFileName,
+	public void HasFile_InvalidFileName_ShouldThrow(string? invalidFileName,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -291,7 +291,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasSingleFileMatching(invalidFileName!, because);
+			sut.HasFile(invalidFileName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -301,7 +301,7 @@ public class DirectoryAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HasSingleFileMatching_WithMatchingFile_ShouldNotThrow(
+	public void HasFile_WithMatchingFile_ShouldNotThrow(
 		string directoryName,
 		string fileName)
 	{
@@ -311,12 +311,12 @@ public class DirectoryAssertionsTests
 				.WithFile(fileName));
 		DirectoryAssertions? sut = fileSystem.Should().HaveDirectory(directoryName).Which;
 
-		sut.HasSingleFileMatching(fileName);
+		sut.HasFile(fileName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HasSingleFileMatching_WithMultipleMatchingFile_ShouldThrow(
+	public void HasFile_WithMultipleMatchingFile_ShouldThrow(
 		string directoryName,
 		string fileName,
 		string because)
@@ -330,7 +330,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasSingleFileMatching($"{fileName}*", because);
+			sut.HasFile($"{fileName}*", because);
 		});
 
 		exception.Should().NotBeNull();
@@ -341,7 +341,7 @@ public class DirectoryAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HasSingleFileMatching_WithoutMatchingFile_ShouldThrow(
+	public void HasFile_WithoutMatchingFile_ShouldThrow(
 		string directoryName,
 		string fileName,
 		string because)
@@ -354,7 +354,7 @@ public class DirectoryAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.HasSingleFileMatching(fileName, because);
+			sut.HasFile(fileName, because);
 		});
 
 		exception.Should().NotBeNull();

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
@@ -88,82 +88,6 @@ public class DirectoryInfoAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HaveFiles_InvalidFileName_ShouldThrow(string? invalidFileName,
-		string because)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory("foo");
-		IDirectoryInfo sut = fileSystem.DirectoryInfo.New("foo");
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.Should().HaveFiles(invalidFileName!, because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should().NotBeNullOrEmpty();
-		exception.Message.Should().NotContain(because);
-	}
-
-	[Theory]
-	[AutoData]
-	public void HaveFiles_Null_ShouldThrow(string because)
-	{
-		IDirectoryInfo? sut = null;
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.Should().HaveFiles(because: because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should().Contain("null");
-		exception.Message.Should().NotContain(because);
-	}
-
-	[Theory]
-	[AutoData]
-	public void HaveFiles_WithMatchingFile_ShouldNotThrow(
-		string directoryName,
-		string fileName)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory(directoryName).Initialized(d => d
-				.WithFile(fileName));
-		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
-
-		sut.Should().HaveFiles(fileName);
-	}
-
-	[Theory]
-	[AutoData]
-	public void HaveFiles_WithoutMatchingFile_ShouldThrow(
-		string directoryName,
-		string fileName,
-		string because)
-	{
-		MockFileSystem fileSystem = new();
-		fileSystem.Initialize()
-			.WithSubdirectory(directoryName).Initialized(d => d
-				.WithFile("not-matching-file"));
-		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
-
-		Exception? exception = Record.Exception(() =>
-		{
-			sut.Should().HaveFiles(fileName, because);
-		});
-
-		exception.Should().NotBeNull();
-		exception!.Message.Should()
-			.Be(
-				$"Expected directory \"{directoryName}\" to contain at least one file matching \"{fileName}\" {because}, but none was found.");
-	}
-
-	[Theory]
-	[InlineAutoData(null)]
-	[InlineAutoData("")]
 	public void HaveDirectory_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
 		string because)
 	{
@@ -359,5 +283,81 @@ public class DirectoryInfoAssertionsTests
 		exception!.Message.Should()
 			.Be(
 				$"Expected directory \"{directoryName}\" to contain exactly one file matching \"{fileName}\" {because}, but found 0.");
+	}
+
+	[Theory]
+	[InlineAutoData(null)]
+	[InlineAutoData("")]
+	public void HaveFiles_InvalidFileName_ShouldThrow(string? invalidFileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory("foo");
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New("foo");
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFiles(invalidFileName!, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().NotBeNullOrEmpty();
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveFiles_Null_ShouldThrow(string because)
+	{
+		IDirectoryInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFiles(because: because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveFiles_WithMatchingFile_ShouldNotThrow(
+		string directoryName,
+		string fileName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile(fileName));
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+
+		sut.Should().HaveFiles(fileName);
+	}
+
+	[Theory]
+	[AutoData]
+	public void HaveFiles_WithoutMatchingFile_ShouldThrow(
+		string directoryName,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithSubdirectory(directoryName).Initialized(d => d
+				.WithFile("not-matching-file"));
+		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFiles(fileName, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected directory \"{directoryName}\" to contain at least one file matching \"{fileName}\" {because}, but none was found.");
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/DirectoryInfoAssertionsTests.cs
@@ -12,7 +12,7 @@ public class DirectoryInfoAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HaveDirectoryMatching_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
+	public void HaveDirectories_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -22,7 +22,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveDirectoryMatching(invalidDirectoryName!, because);
+			sut.Should().HaveDirectories(invalidDirectoryName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -32,13 +32,13 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveDirectoryMatching_Null_ShouldThrow(string because)
+	public void HaveDirectories_Null_ShouldThrow(string because)
 	{
 		IDirectoryInfo? sut = null;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveDirectoryMatching(because: because);
+			sut.Should().HaveDirectories(because: because);
 		});
 
 		exception.Should().NotBeNull();
@@ -48,7 +48,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveDirectoryMatching_WithMatchingDirectory_ShouldNotThrow(
+	public void HaveDirectories_WithMatchingDirectory_ShouldNotThrow(
 		string directoryName,
 		string subdirectoryName)
 	{
@@ -58,12 +58,12 @@ public class DirectoryInfoAssertionsTests
 				.WithSubdirectory(subdirectoryName));
 		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
 
-		sut.Should().HaveDirectoryMatching(subdirectoryName);
+		sut.Should().HaveDirectories(subdirectoryName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveDirectoryMatching_WithoutMatchingDirectory_ShouldThrow(
+	public void HaveDirectories_WithoutMatchingDirectory_ShouldThrow(
 		string directoryName,
 		string subdirectoryName,
 		string because)
@@ -76,7 +76,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveDirectoryMatching(subdirectoryName, because);
+			sut.Should().HaveDirectories(subdirectoryName, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -88,7 +88,7 @@ public class DirectoryInfoAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HaveFileMatching_InvalidFileName_ShouldThrow(string? invalidFileName,
+	public void HaveFiles_InvalidFileName_ShouldThrow(string? invalidFileName,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -98,7 +98,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveFileMatching(invalidFileName!, because);
+			sut.Should().HaveFiles(invalidFileName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -108,13 +108,13 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveFileMatching_Null_ShouldThrow(string because)
+	public void HaveFiles_Null_ShouldThrow(string because)
 	{
 		IDirectoryInfo? sut = null;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveFileMatching(because: because);
+			sut.Should().HaveFiles(because: because);
 		});
 
 		exception.Should().NotBeNull();
@@ -124,7 +124,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveFileMatching_WithMatchingFile_ShouldNotThrow(
+	public void HaveFiles_WithMatchingFile_ShouldNotThrow(
 		string directoryName,
 		string fileName)
 	{
@@ -134,12 +134,12 @@ public class DirectoryInfoAssertionsTests
 				.WithFile(fileName));
 		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
 
-		sut.Should().HaveFileMatching(fileName);
+		sut.Should().HaveFiles(fileName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveFileMatching_WithoutMatchingFile_ShouldThrow(
+	public void HaveFiles_WithoutMatchingFile_ShouldThrow(
 		string directoryName,
 		string fileName,
 		string because)
@@ -152,7 +152,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveFileMatching(fileName, because);
+			sut.Should().HaveFiles(fileName, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -164,7 +164,7 @@ public class DirectoryInfoAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HaveSingleDirectory_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
+	public void HaveDirectory_InvalidDirectoryName_ShouldThrow(string? invalidDirectoryName,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -174,7 +174,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleDirectory(invalidDirectoryName!, because);
+			sut.Should().HaveDirectory(invalidDirectoryName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -184,13 +184,13 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleDirectory_Null_ShouldThrow(string because)
+	public void HaveDirectory_Null_ShouldThrow(string because)
 	{
 		IDirectoryInfo? sut = null;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleDirectory(because: because);
+			sut.Should().HaveDirectory(because: because);
 		});
 
 		exception.Should().NotBeNull();
@@ -200,7 +200,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleDirectory_WithMatchingDirectory_ShouldNotThrow(
+	public void HaveDirectory_WithMatchingDirectory_ShouldNotThrow(
 		string directoryName,
 		string subdirectoryName)
 	{
@@ -210,12 +210,12 @@ public class DirectoryInfoAssertionsTests
 				.WithSubdirectory(subdirectoryName));
 		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
 
-		sut.Should().HaveSingleDirectory(subdirectoryName);
+		sut.Should().HaveDirectory(subdirectoryName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleDirectory_WithMultipleMatchingDirectory_ShouldThrow(
+	public void HaveDirectory_WithMultipleMatchingDirectory_ShouldThrow(
 		string directoryName,
 		string because)
 	{
@@ -228,7 +228,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleDirectory("directory*.txt", because);
+			sut.Should().HaveDirectory("directory*.txt", because);
 		});
 
 		exception.Should().NotBeNull();
@@ -239,7 +239,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleDirectory_WithoutMatchingDirectory_ShouldThrow(
+	public void HaveDirectory_WithoutMatchingDirectory_ShouldThrow(
 		string directoryName,
 		string subdirectoryName,
 		string because)
@@ -252,7 +252,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleDirectory(subdirectoryName, because);
+			sut.Should().HaveDirectory(subdirectoryName, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -264,7 +264,7 @@ public class DirectoryInfoAssertionsTests
 	[Theory]
 	[InlineAutoData(null)]
 	[InlineAutoData("")]
-	public void HaveSingleFile_InvalidFileName_ShouldThrow(string? invalidFileName,
+	public void HaveFile_InvalidFileName_ShouldThrow(string? invalidFileName,
 		string because)
 	{
 		MockFileSystem fileSystem = new();
@@ -274,7 +274,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleFile(invalidFileName!, because);
+			sut.Should().HaveFile(invalidFileName!, because);
 		});
 
 		exception.Should().NotBeNull();
@@ -284,13 +284,13 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleFile_Null_ShouldThrow(string because)
+	public void HaveFile_Null_ShouldThrow(string because)
 	{
 		IDirectoryInfo? sut = null;
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleFile(because: because);
+			sut.Should().HaveFile(because: because);
 		});
 
 		exception.Should().NotBeNull();
@@ -300,7 +300,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleFile_WithMatchingFile_ShouldNotThrow(
+	public void HaveFile_WithMatchingFile_ShouldNotThrow(
 		string directoryName,
 		string fileName)
 	{
@@ -310,12 +310,12 @@ public class DirectoryInfoAssertionsTests
 				.WithFile(fileName));
 		IDirectoryInfo sut = fileSystem.DirectoryInfo.New(directoryName);
 
-		sut.Should().HaveSingleFile(fileName);
+		sut.Should().HaveFile(fileName);
 	}
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleFile_WithMultipleMatchingFile_ShouldThrow(
+	public void HaveFile_WithMultipleMatchingFile_ShouldThrow(
 		string directoryName,
 		string because)
 	{
@@ -328,7 +328,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleFile("file*.txt", because);
+			sut.Should().HaveFile("file*.txt", because);
 		});
 
 		exception.Should().NotBeNull();
@@ -339,7 +339,7 @@ public class DirectoryInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
-	public void HaveSingleFile_WithoutMatchingFile_ShouldThrow(
+	public void HaveFile_WithoutMatchingFile_ShouldThrow(
 		string directoryName,
 		string fileName,
 		string because)
@@ -352,7 +352,7 @@ public class DirectoryInfoAssertionsTests
 
 		Exception? exception = Record.Exception(() =>
 		{
-			sut.Should().HaveSingleFile(fileName, because);
+			sut.Should().HaveFile(fileName, because);
 		});
 
 		exception.Should().NotBeNull();


### PR DESCRIPTION
Simplify and consolidate the assertion names, e.g.
- `HasSingleDirectory` -> `HasDirectory`
- `HasDirectoriesMatching` -> `HasDirectories`
- `HasSingleFile` -> `HasFile`
- `HasFilesMatching` -> `HasFiles`