### PR TITLE
feat: add assertions for `HasFileShare`

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
@@ -63,7 +63,7 @@ public class FileAssertions :
 			.Given(() => Subject!)
 			.ForCondition(fileInfo => !CheckFileShare(fileInfo, fileShare))
 			.FailWith(
-				$"Expected {{context}} {{0}} to have file share '{fileShare}'{{reason}}, but it did not.",
+				$"Expected {{context}} {{0}} not to have file share '{fileShare}'{{reason}}, but it did.",
 				fileInfo => fileInfo.Name);
 
 		return new AndConstraint<FileAssertions>(this);

--- a/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileAssertions.cs
@@ -41,6 +41,35 @@ public class FileAssertions :
 	}
 
 	/// <summary>
+	///     Asserts that the current file does not have the given <paramref name="fileShare" />, indicating if the it is
+	///     available for reading or writing:
+	///     <br />
+	///     - When set to <see cref="FileShare.Read" />, the file cannot be opened for reading
+	///     <br />
+	///     - When set to <see cref="FileShare.Write" />, the file cannot be opened for writing
+	///     <br />
+	///     - When set to <see cref="FileShare.ReadWrite" />, the file cannot be opened for reading and writing
+	/// </summary>
+	public AndConstraint<FileAssertions> DoesNotHaveFileShare(
+		FileShare fileShare, string because = "", params object[] becauseArgs)
+	{
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.ForCondition(Subject != null)
+			.FailWith(
+				$"You can't assert that the file does not have file share {fileShare} if it is null.")
+			.Then
+			.Given(() => Subject!)
+			.ForCondition(fileInfo => !CheckFileShare(fileInfo, fileShare))
+			.FailWith(
+				$"Expected {{context}} {{0}} to have file share '{fileShare}'{{reason}}, but it did not.",
+				fileInfo => fileInfo.Name);
+
+		return new AndConstraint<FileAssertions>(this);
+	}
+
+	/// <summary>
 	///     Asserts that the current file has the given <paramref name="attribute" />.
 	/// </summary>
 	public AndConstraint<FileAssertions> HasAttribute(
@@ -134,6 +163,35 @@ public class FileAssertions :
 	}
 
 	/// <summary>
+	///     Asserts that the current file has the given <paramref name="fileShare" />, indicating if the it is
+	///     available for reading or writing:
+	///     <br />
+	///     - When set to <see cref="FileShare.Read" />, the file can be opened for reading
+	///     <br />
+	///     - When set to <see cref="FileShare.Write" />, the file can be opened for writing
+	///     <br />
+	///     - When set to <see cref="FileShare.ReadWrite" />, the file can be opened for reading and writing
+	/// </summary>
+	public AndConstraint<FileAssertions> HasFileShare(
+		FileShare fileShare, string because = "", params object[] becauseArgs)
+	{
+		Execute.Assertion
+			.WithDefaultIdentifier(Identifier)
+			.BecauseOf(because, becauseArgs)
+			.ForCondition(Subject != null)
+			.FailWith(
+				$"You can't assert that the file has file share {fileShare} if it is null.")
+			.Then
+			.Given(() => Subject!)
+			.ForCondition(fileInfo => CheckFileShare(fileInfo, fileShare))
+			.FailWith(
+				$"Expected {{context}} {{0}} to have file share '{fileShare}'{{reason}}, but it did not.",
+				fileInfo => fileInfo.Name);
+
+		return new AndConstraint<FileAssertions>(this);
+	}
+
+	/// <summary>
 	///     Asserts that the current file is not read-only.
 	/// </summary>
 	public AndConstraint<FileAssertions> IsNotReadOnly(
@@ -175,5 +233,44 @@ public class FileAssertions :
 				fileInfo => fileInfo.Name);
 
 		return new AndConstraint<FileAssertions>(this);
+	}
+
+	private static bool CheckFileShare(IFileInfo fileInfo, FileShare fileShare)
+	{
+		if (fileShare.HasFlag(FileShare.Read))
+		{
+			try
+			{
+				fileInfo.FileSystem.File.Open(
+						fileInfo.FullName,
+						FileMode.Open,
+						FileAccess.Read,
+						FileShare.ReadWrite)
+					.Dispose();
+			}
+			catch (IOException)
+			{
+				return false;
+			}
+		}
+
+		if (fileShare.HasFlag(FileShare.Write))
+		{
+			try
+			{
+				fileInfo.FileSystem.File.Open(
+						fileInfo.FullName,
+						FileMode.Open,
+						FileAccess.Write,
+						FileShare.ReadWrite)
+					.Dispose();
+			}
+			catch (IOException)
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 }

--- a/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileInfoAssertions.cs
@@ -69,6 +69,23 @@ public class FileInfoAssertions :
 	}
 
 	/// <summary>
+	///     Asserts that the current file has the given <paramref name="fileShare" />, indicating if the it is
+	///     available for reading or writing:
+	///     <br />
+	///     - When set to <see cref="FileShare.Read" />, the file can be opened for reading
+	///     <br />
+	///     - When set to <see cref="FileShare.Write" />, the file can be opened for writing
+	///     <br />
+	///     - When set to <see cref="FileShare.ReadWrite" />, the file can be opened for reading and writing
+	/// </summary>
+	public AndConstraint<FileInfoAssertions> HaveFileShare(
+		FileShare fileShare, string because = "", params object[] becauseArgs)
+	{
+		new FileAssertions(Subject).HasFileShare(fileShare, because, becauseArgs);
+		return new AndConstraint<FileInfoAssertions>(this);
+	}
+
+	/// <summary>
 	///     Asserts that the current file is not read-only.
 	/// </summary>
 	public AndConstraint<FileInfoAssertions> NotBeReadOnly(
@@ -85,6 +102,23 @@ public class FileInfoAssertions :
 		FileAttributes attribute, string because = "", params object[] becauseArgs)
 	{
 		new FileAssertions(Subject).DoesNotHaveAttribute(attribute, because, becauseArgs);
+		return new AndConstraint<FileInfoAssertions>(this);
+	}
+
+	/// <summary>
+	///     Asserts that the current file does not have the given <paramref name="fileShare" />, indicating if the it is
+	///     available for reading or writing:
+	///     <br />
+	///     - When set to <see cref="FileShare.Read" />, the file cannot be opened for reading
+	///     <br />
+	///     - When set to <see cref="FileShare.Write" />, the file cannot be opened for writing
+	///     <br />
+	///     - When set to <see cref="FileShare.ReadWrite" />, the file cannot be opened for reading and writing
+	/// </summary>
+	public AndConstraint<FileInfoAssertions> NotHaveFileShare(
+		FileShare fileShare, string because = "", params object[] becauseArgs)
+	{
+		new FileAssertions(Subject).DoesNotHaveFileShare(fileShare, because, becauseArgs);
 		return new AndConstraint<FileInfoAssertions>(this);
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileAssertionsTests.cs
@@ -75,7 +75,7 @@ public class FileAssertionsTests
 		exception.Should().NotBeNull();
 		exception!.Message.Should()
 			.Be(
-				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
+				$"Expected file \"{fileName}\" not to have file share '{fileShare}' {because}, but it did.");
 	}
 
 	[Theory]
@@ -125,7 +125,7 @@ public class FileAssertionsTests
 		exception.Should().NotBeNull();
 		exception!.Message.Should()
 			.Be(
-				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
+				$"Expected file \"{fileName}\" not to have file share '{fileShare}' {because}, but it did.");
 	}
 
 	[Theory]

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
@@ -324,6 +324,92 @@ public class FileInfoAssertionsTests
 
 	[Theory]
 	[AutoData]
+	public void HaveFileShare_Null_ShouldThrow(FileShare fileShare, string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFileShare(fileShare, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+		exception.Message.Should().Contain(fileShare.ToString());
+	}
+
+	[Theory]
+	[InlineAutoData(FileShare.Read)]
+	[InlineAutoData(FileShare.Write)]
+	[InlineAutoData(FileShare.ReadWrite)]
+	[InlineAutoData(FileShare.Delete)]
+	[InlineAutoData(FileShare.None)]
+	[InlineAutoData(FileShare.Inheritable)]
+	public void HaveFileShare_UnlockedFile_ShouldHaveAllFileShares(
+		FileShare fileShare,
+		string fileName)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithFile(fileName);
+		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+
+		sut.Should().HaveFileShare(fileShare);
+	}
+
+	[Theory]
+	[InlineAutoData(FileShare.Read)]
+	[InlineAutoData(FileShare.Write)]
+	[InlineAutoData(FileShare.ReadWrite)]
+	public void HaveFileShare_WhenLockDoesNotShare_ShouldThrow(
+		FileShare fileShare,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithFile(fileName);
+		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		using FileSystemStream stream = fileSystem.File.Open(
+			fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFileShare(fileShare, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
+	}
+
+	[Theory]
+	[InlineAutoData(FileShare.Read)]
+	[InlineAutoData(FileShare.Write)]
+	public void HaveFileShare_WhenLockSharesFile_ShouldNotThrow(
+		FileShare fileShare,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithFile(fileName);
+		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		using FileSystemStream stream = fileSystem.File.Open(
+			fileName, FileMode.Open, FileAccess.ReadWrite, fileShare);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().HaveFileShare(fileShare, because);
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[Theory]
+	[AutoData]
 	public void NotBeReadOnly_Null_ShouldThrow(string because)
 	{
 		IFileInfo? sut = null;
@@ -424,5 +510,100 @@ public class FileInfoAssertionsTests
 		IFileInfo sut = fileSystem.FileInfo.New(fileDescription.Name);
 
 		sut.Should().NotHaveAttribute(FileAttributes.ReadOnly);
+	}
+
+	[Theory]
+	[AutoData]
+	public void NotHaveFileShare_Null_ShouldThrow(FileShare fileShare, string because)
+	{
+		IFileInfo? sut = null;
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().NotHaveFileShare(fileShare, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should().Contain("null");
+		exception.Message.Should().NotContain(because);
+		exception.Message.Should().Contain(fileShare.ToString());
+	}
+
+	[Theory]
+	[InlineAutoData(FileShare.Read)]
+	[InlineAutoData(FileShare.Write)]
+	[InlineAutoData(FileShare.ReadWrite)]
+	[InlineAutoData(FileShare.Delete)]
+	[InlineAutoData(FileShare.None)]
+	[InlineAutoData(FileShare.Inheritable)]
+	public void NotHaveFileShare_UnlockedFile_ShouldThrow(
+		FileShare fileShare,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithFile(fileName);
+		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().NotHaveFileShare(fileShare, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
+	}
+
+	[Theory]
+	[InlineAutoData(FileShare.Read)]
+	[InlineAutoData(FileShare.Write)]
+	public void NotHaveFileShare_WhenLockDoesNotShare_ShouldNotThrow(
+		FileShare fileShare,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithFile(fileName);
+		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		using FileSystemStream stream = fileSystem.File.Open(
+			fileName, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().NotHaveFileShare(fileShare, because);
+		});
+
+		exception.Should().BeNull();
+	}
+
+	[Theory]
+	[InlineAutoData(FileShare.Read)]
+	[InlineAutoData(FileShare.Write)]
+	[InlineAutoData(FileShare.ReadWrite)]
+	public void NotHaveFileShare_WhenLockSharesFile_ShouldThrow(
+		FileShare fileShare,
+		string fileName,
+		string because)
+	{
+		MockFileSystem fileSystem = new();
+		fileSystem.Initialize()
+			.WithFile(fileName);
+		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+		using FileSystemStream stream = fileSystem.File.Open(
+			fileName, FileMode.Open, FileAccess.ReadWrite, fileShare);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().NotHaveFileShare(fileShare, because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
 	}
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileInfoAssertionsTests.cs
@@ -554,7 +554,7 @@ public class FileInfoAssertionsTests
 		exception.Should().NotBeNull();
 		exception!.Message.Should()
 			.Be(
-				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
+				$"Expected file \"{fileName}\" not to have file share '{fileShare}' {because}, but it did.");
 	}
 
 	[Theory]
@@ -604,6 +604,6 @@ public class FileInfoAssertionsTests
 		exception.Should().NotBeNull();
 		exception!.Message.Should()
 			.Be(
-				$"Expected file \"{fileName}\" to have file share '{fileShare}' {because}, but it did not.");
+				$"Expected file \"{fileName}\" not to have file share '{fileShare}' {because}, but it did.");
 	}
 }


### PR DESCRIPTION
Add assertions for `HasFileShare` and `DoesNotHaveFileShare` that checks, if the file can be accessed with the given `FileShare`.