### PR TITLE
feat: enable assertions on `IFileSystemInfo`

### DIFF
--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemExtensions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemExtensions.cs
@@ -20,6 +20,13 @@ public static class FileSystemExtensions
 		=> new(instance);
 
 	/// <summary>
+	///     Returns a <see cref="FileAssertions" /> object that can be used to
+	///     assert the current <see cref="IFileInfo" />.
+	/// </summary>
+	public static FileSystemInfoAssertions Should(this IFileSystemInfo? instance)
+		=> new(instance);
+
+	/// <summary>
 	///     Returns a <see cref="FileSystemAssertions" /> object that can be used to
 	///     assert the current <see cref="IFileSystem" />.
 	/// </summary>

--- a/Source/Testably.Abstractions.FluentAssertions/FileSystemInfoAssertions.cs
+++ b/Source/Testably.Abstractions.FluentAssertions/FileSystemInfoAssertions.cs
@@ -3,6 +3,21 @@
 /// <summary>
 ///     Assertions on <see cref="IFileSystemInfo" />.
 /// </summary>
+public class FileSystemInfoAssertions :
+	FileSystemInfoAssertions<IFileSystemInfo, FileSystemInfoAssertions>
+{
+	/// <inheritdoc cref="ReferenceTypeAssertions{TSubject,TAssertions}.Identifier" />
+	protected override string Identifier => "file system info";
+
+	internal FileSystemInfoAssertions(IFileSystemInfo? instance)
+		: base(instance)
+	{
+	}
+}
+
+/// <summary>
+///     Assertions on <see cref="IFileSystemInfo" />.
+/// </summary>
 public abstract class
 	FileSystemInfoAssertions<TFileSystemInfo, TAssertion>
 	: ReferenceTypeAssertions<TFileSystemInfo?, TAssertion>

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemInfoAssertionsTests.cs
@@ -149,6 +149,7 @@ public class FileSystemInfoAssertionsTests
 			.Be($"Expected file \"{fileName}\" to exist {because}, but it did not.");
 	}
 
+#if NET
 	[SkippableTheory]
 	[AutoData]
 	public void Exist_ForFileSystemInfo_WithExistingFile_ShouldNotThrow(
@@ -185,6 +186,7 @@ public class FileSystemInfoAssertionsTests
 			.Be(
 				$"Expected file system info \"{pathToTarget}\" to exist {because}, but it did not.");
 	}
+#endif
 
 	[Theory]
 	[AutoData]
@@ -313,6 +315,7 @@ public class FileSystemInfoAssertionsTests
 		sut.Should().NotExist(because);
 	}
 
+#if NET
 	[SkippableTheory]
 	[AutoData]
 	public void NotExist_ForFileSystemInfo_WithExistingFile_ShouldThrow(
@@ -349,4 +352,5 @@ public class FileSystemInfoAssertionsTests
 
 		sut.Should().NotExist(because);
 	}
+#endif
 }

--- a/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemInfoAssertionsTests.cs
+++ b/Tests/Testably.Abstractions.FluentAssertions.Tests/FileSystemInfoAssertionsTests.cs
@@ -149,6 +149,43 @@ public class FileSystemInfoAssertionsTests
 			.Be($"Expected file \"{fileName}\" to exist {because}, but it did not.");
 	}
 
+	[SkippableTheory]
+	[AutoData]
+	public void Exist_ForFileSystemInfo_WithExistingFile_ShouldNotThrow(
+		string path, string pathToTarget, string because)
+	{
+		MockFileSystem fileSystem = new();
+		string targetFullPath = fileSystem.Path.GetFullPath(pathToTarget);
+		fileSystem.Directory.CreateDirectory(pathToTarget);
+		fileSystem.Directory.CreateSymbolicLink(path, targetFullPath);
+		IFileSystemInfo? sut =
+			fileSystem.Directory.ResolveLinkTarget(path, false);
+
+		sut.Should().Exist(because);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void Exist_ForFileSystemInfo_WithoutExistingFile_ShouldThrow(
+		string path, string pathToTarget, string because)
+	{
+		MockFileSystem fileSystem = new();
+		string targetFullPath = fileSystem.Path.GetFullPath(pathToTarget);
+		fileSystem.Directory.CreateSymbolicLink(path, targetFullPath);
+		IFileSystemInfo? sut =
+			fileSystem.Directory.ResolveLinkTarget(path, false);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().Exist(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected file system info \"{pathToTarget}\" to exist {because}, but it did not.");
+	}
+
 	[Theory]
 	[AutoData]
 	public void NotExist_ForDirectoryInfo_Null_ShouldThrow(string because)
@@ -272,6 +309,43 @@ public class FileSystemInfoAssertionsTests
 		fileSystem.Initialize();
 		fileSystem.Directory.CreateDirectory(fileName);
 		IFileInfo sut = fileSystem.FileInfo.New(fileName);
+
+		sut.Should().NotExist(because);
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void NotExist_ForFileSystemInfo_WithExistingFile_ShouldThrow(
+		string path, string pathToTarget, string because)
+	{
+		MockFileSystem fileSystem = new();
+		string targetFullPath = fileSystem.Path.GetFullPath(pathToTarget);
+		fileSystem.Directory.CreateDirectory(pathToTarget);
+		fileSystem.Directory.CreateSymbolicLink(path, targetFullPath);
+		IFileSystemInfo? sut =
+			fileSystem.Directory.ResolveLinkTarget(path, false);
+
+		Exception? exception = Record.Exception(() =>
+		{
+			sut.Should().NotExist(because);
+		});
+
+		exception.Should().NotBeNull();
+		exception!.Message.Should()
+			.Be(
+				$"Expected file system info \"{pathToTarget}\" not to exist {because}, but it did.");
+	}
+
+	[SkippableTheory]
+	[AutoData]
+	public void NotExist_ForFileSystemInfo_WithoutExistingFile_ShouldNotThrow(
+		string path, string pathToTarget, string because)
+	{
+		MockFileSystem fileSystem = new();
+		string targetFullPath = fileSystem.Path.GetFullPath(pathToTarget);
+		fileSystem.Directory.CreateSymbolicLink(path, targetFullPath);
+		IFileSystemInfo? sut =
+			fileSystem.Directory.ResolveLinkTarget(path, false);
 
 		sut.Should().NotExist(because);
 	}


### PR DESCRIPTION
Enable assertions directly on `IFileSystemInfo`, e.g. when returned from `ResolveLinkTarget`.