### PR TITLE
docs: Mark package as no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# NO LONGER MAINTAINED
+
+**Due to the license update of FluentAssertions, this package is no longer maintained!**
+
+
 ![Testably.Abstractions.FluentAssertions](https://raw.githubusercontent.com/Testably/Testably.Abstractions.FluentAssertions/main/Docs/Images/social-preview.png)  
 [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions.FluentAssertions)](https://www.nuget.org/packages/Testably.Abstractions.FluentAssertions)
 [![Build](https://github.com/Testably/Testably.Abstractions.FluentAssertions/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/Testably.Abstractions.FluentAssertions/actions/workflows/build.yml)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 **Due to the license update of FluentAssertions, this package is no longer maintained!**
 
+---
+# Testably.Abstractions.FluentAssertions
 
-![Testably.Abstractions.FluentAssertions](https://raw.githubusercontent.com/Testably/Testably.Abstractions.FluentAssertions/main/Docs/Images/social-preview.png)  
 [![Nuget](https://img.shields.io/nuget/v/Testably.Abstractions.FluentAssertions)](https://www.nuget.org/packages/Testably.Abstractions.FluentAssertions)
 [![Build](https://github.com/Testably/Testably.Abstractions.FluentAssertions/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/Testably.Abstractions.FluentAssertions/actions/workflows/build.yml)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/5b9b2f79950447a69d69037b43acd590)](https://app.codacy.com/gh/Testably/Testably.Abstractions.FluentAssertions/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)


### PR DESCRIPTION
Added a notice indicating that the package is no longer maintained due to a license update.